### PR TITLE
Improve mg_import_tool documentation

### DIFF
--- a/products/memgraph/v0.14.1/how_to_guides/import-data.md
+++ b/products/memgraph/v0.14.1/how_to_guides/import-data.md
@@ -11,6 +11,12 @@ CSV data should be in Neo4j CSV compatible format. Detailed format
 specification can be found
 [here](https://neo4j.com/docs/operations-manual/current/tools/import/file-header-format/).
 
+As you can see from the link above, the header mostly consists of
+`<name>:<field_type>` pairs. If the `<field_type>` is absent, the import tool
+will default to `string`.
+
+#### How to Use the CSV Import Tool?
+
 The import tool is run from the console, using the `mg_import_csv` command.
 
 If you installed Memgraph using Docker, you will need to run the importer
@@ -28,14 +34,25 @@ relationships) are passed via the `--relationships` option.  Multiple
 relationship files are imported by repeating the option. Unlike nodes,
 relationships are not required.
 
-After reading the CSV files, the tool will by default search for the installed
-Memgraph configuration. If the configuration is found, the data will be
-written in the configured durability directory. If the configuration isn't
-found, you will need to use the `--out` option to specify the output file. You
-can use the same option to override the default behaviour.
+Internally, the CSV import tool creates a database snapshot from the CSV files.
+By default, the tool will search for the installed Memgraph configuration and
+will store the snapshot inside its configured durability directory. If the
+configuration isn't found, you will need to use the `--out` option to specify
+the output file. Naturally, you can use the same option to override the default
+behaviour.
 
 Memgraph will recover the imported data on the next startup by looking in the
-durability directory.
+durability directory. It is important to note that your durability directory
+should not contain any WAL files when using the CSV import tool. If it does,
+Memgraph will try to recover from those files as well and they are most likely
+not compatible with the contents of the newly created snapshot. For more
+details on Memgraph's durability and data recovery features, please check out
+the appropriate [article](../concepts/storage.md).
+
+It is also important to note that importing CSV data using the `mg_import_csv`
+command should be a one-time operation before running Memgraph. In other
+words, this tool should not be used to import data into an already running
+Memgraph instance.
 
 For information on other options, run:
 
@@ -89,7 +106,7 @@ And finally, set relationships between comments and forums in
 
 Now, you can import the dataset in Memgraph.
 
-WARNING: Your existing recovery data will be considered obsolete, and Memgraph
+WARNING: Your existing snapshot will be considered obsolete, and Memgraph
 will load the new dataset.
 
 Use the following command:


### PR DESCRIPTION
The issues we received:

-  Headers without types sometimes break (our implementation has a default type which is not documented).
-  When trying to run the csv import tool with existing durability directory which has WAL files, the whole thing will crash
-  It's not clear how to import data stored in multiple files
-  It's not clear that csv import should be a one-time operation before running Memgraph. Therefore, users try to import data while they have a running Memgraph instance.