### PR TITLE
Replace links to each tutorial with link to tutorial overview

### DIFF
--- a/products/memgraph/upcoming/tutorials/analyzing-TED-talks.md
+++ b/products/memgraph/upcoming/tutorials/analyzing-TED-talks.md
@@ -5,7 +5,7 @@ on real-world data to retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/analyzing-TED-talks.md
+++ b/products/memgraph/upcoming/tutorials/analyzing-TED-talks.md
@@ -4,6 +4,9 @@ This article is a part of a series intended to show how to use Memgraph
 on real-world data to retrieve some interesting and useful
 information.
 
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
+
 ### Introduction
 
 [TED](https://www.ted.com/) is a nonprofit organization devoted to spreading
@@ -179,14 +182,3 @@ WITH DISTINCT n, m ORDER BY m.name
 RETURN n.name AS Speaker, COLLECT(m.name) AS Others
 ORDER BY Speaker;
 ```
-
-### Where To Next?
-
-We recommend checking out other tutorials from this series:
-
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)
-  * [Football Transfers](football-transfers.md)

--- a/products/memgraph/upcoming/tutorials/backpacking-through-europe.md
+++ b/products/memgraph/upcoming/tutorials/backpacking-through-europe.md
@@ -4,14 +4,8 @@ This article is a part of a series intended to show users how to use Memgraph
 on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
-We highly recommend checking out the other articles from this series:
-
-  * [Analyzing TED Talks](analyzing-TED-talks.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)
-  * [Football Transfers](football-transfers.md)
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/backpacking-through-europe.md
+++ b/products/memgraph/upcoming/tutorials/backpacking-through-europe.md
@@ -5,7 +5,7 @@ on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/exploring-the-european-road-network.md
+++ b/products/memgraph/upcoming/tutorials/exploring-the-european-road-network.md
@@ -4,14 +4,8 @@ This article is a part of a series intended to show users how to use Memgraph
 on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
-We highly recommend checking out the other articles from this series:
-
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Analyzing TED Talks](analyzing-TED-talks.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)
-  * [Football Transfers](football-transfers.md)
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/exploring-the-european-road-network.md
+++ b/products/memgraph/upcoming/tutorials/exploring-the-european-road-network.md
@@ -5,7 +5,7 @@ on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/football-transfers.md
+++ b/products/memgraph/upcoming/tutorials/football-transfers.md
@@ -5,7 +5,7 @@ on real-world data to retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/football-transfers.md
+++ b/products/memgraph/upcoming/tutorials/football-transfers.md
@@ -4,6 +4,9 @@ This article is a part of a series intended to show how to use Memgraph
 on real-world data to retrieve some interesting and useful
 information.
 
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
+
 ### Introduction
 
 Football is a word that could mean one of several sports. In this article,
@@ -381,13 +384,3 @@ With that in mind, our results contain all the information for the graph visual:
 Here is a picture of how it will look if you run the query in MemgraphLab.
 
 ![](../data/football_transfers_MemgraphLab_visual.png)
-
-### Where To Next?
-
-We recommend checking out other tutorials from this series:
-
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)

--- a/products/memgraph/upcoming/tutorials/graphing-the-premier-league.md
+++ b/products/memgraph/upcoming/tutorials/graphing-the-premier-league.md
@@ -4,14 +4,8 @@ This article is a part of a series intended to show users how to use Memgraph
 on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
-We highly recommend checking out the other articles from this series:
-
-  * [Analyzing TED Talks](analyzing-TED-talks.md)
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)
-  * [Football Transfers](football-transfers.md)
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/graphing-the-premier-league.md
+++ b/products/memgraph/upcoming/tutorials/graphing-the-premier-league.md
@@ -5,7 +5,7 @@ on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/marvel-universe.md
+++ b/products/memgraph/upcoming/tutorials/marvel-universe.md
@@ -5,7 +5,7 @@ on real-world data to retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/marvel-universe.md
+++ b/products/memgraph/upcoming/tutorials/marvel-universe.md
@@ -17,15 +17,6 @@ wanted to know who's Spider-Man's best super-buddy, or wanted to find all the
 comic issues where Hulk, Wolverine, Thor, and Black Panther appear together, look
 no further and fire up that Memgraph copy of yours!
 
-We highly recommend checking out the other articles from this series:
-
-  * [Analyzing TED Talks](analyzing-TED-talks.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Movie Recommendation System](movie-recommendation.md)
-  * [Football Transfers](football-transfers.md)
-
 ### Data Model
 
 Although the MCU is chock-full of heroes, the real hero here is Russ Chappell,

--- a/products/memgraph/upcoming/tutorials/marvel-universe.md
+++ b/products/memgraph/upcoming/tutorials/marvel-universe.md
@@ -1,5 +1,12 @@
 ## Marvel Comic Universe Social Network
 
+This article is a part of a series intended to show how to use Memgraph
+on real-world data to retrieve some interesting and useful
+information.
+
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
+
 ### Introduction
 
 Spandex. Muscles. Big egos. Bad hair. No, we're not talking about your high

--- a/products/memgraph/upcoming/tutorials/movie-recommendation.md
+++ b/products/memgraph/upcoming/tutorials/movie-recommendation.md
@@ -4,14 +4,8 @@ This article is a part of a series intended to show users how to use Memgraph
 on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
-We highly recommend checking out the other articles from this series:
-
-  * [Analyzing TED Talks](analyzing-TED-talks.md)
-  * [Graphing the Premier League](graphing-the-premier-league.md)
-  * [Exploring the European Road Network](exploring-the-european-road-network.md)
-  * [Backpacking Through Europe](backpacking-through-europe.md)
-  * [Marvel Comic Universe Social Network](marvel-universe.md)
-  * [Football Transfers](football-transfers.md)
+We highly recommend checking out the other articles from this series which
+are listed in our [tutorial overivew section](tutorials-overview.md).
 
 ### Introduction
 

--- a/products/memgraph/upcoming/tutorials/movie-recommendation.md
+++ b/products/memgraph/upcoming/tutorials/movie-recommendation.md
@@ -5,7 +5,7 @@ on real-world data and, by doing so, retrieve some interesting and useful
 information.
 
 We highly recommend checking out the other articles from this series which
-are listed in our [tutorial overivew section](tutorials-overview.md).
+are listed in our [tutorial overview section](tutorials-overview.md).
 
 ### Introduction
 


### PR DESCRIPTION
Having in each tutorial links to other tutorials makes it really hard to mantain.
Also, the list of tutorials isn't that short anymore.
This seems like a more managable solution while keeping the same functionality.