### PR TITLE
Cypher styling overhaul

### DIFF
--- a/docs/tutorials/backpacking-through-europe.md
+++ b/docs/tutorials/backpacking-through-europe.md
@@ -163,15 +163,13 @@ Let's list our top 10 options sorted by the total trip cost and number of
 cities in the path.
 
 ```cypher
-MATCH path = (n:City {name: "Paris"})-[:CloseTo *3..5]-(m:City {name: "Zagreb"}) 
-WITH nodes(path) AS trip
-WITH extract(city in trip | [city, trip]) AS lst
-UNWIND lst AS rows
-WITH rows[0] AS city, extract(city in rows[1] | city.name) AS trip
-RETURN trip,
-       toInteger(sum(city.total_USD)) AS trip_cost_USD,
-       count(trip) AS city_count
-ORDER BY trip_cost_USD, city_count DESC LIMIT 10;
+MATCH path = (:City {name: "Paris"}) - [:CloseTo * 3..5] - (:City {name: "Zagreb"})
+WITH nodes(path) AS list
+UNWIND list AS rows
+RETURN EXTRACT(city IN list | city.name) AS cities,
+       ROUND(SUM(rows.total_USD)) AS cost,
+       count(list) AS city_count
+ORDER BY cost, city_count DESC LIMIT 10
 ```
 
 Here we can see the usage of the variable length paths.

--- a/docs/tutorials/marvel-universe.md
+++ b/docs/tutorials/marvel-universe.md
@@ -82,10 +82,8 @@ Here are some queries you might find interesting:
 
 ```cypher
 MATCH (s:ComicSeries)-[:IsPartOfSeries]-(c:Comic)
-WITH s.title as Series,
-c as Comic
-return Series, count(Comic) as ComicCount
-ORDER BY Series;
+return s.title as series, count(c) as comics
+ORDER BY series;
 ```
 
 2) List all heroes that have "SPIDER" in their name:
@@ -98,10 +96,17 @@ for. One of the most flexible ways is to use regex matching (represented by the
 regex-matching operator "=~").
 
 ```cypher
-MATCH (h:Hero) WHERE
-h.name =~ ".*SPIDER.+"
-RETURN h.name as PotentialSpiderDude
-ORDER BY PotentialSpiderDude;
+MATCH (hero:Hero)
+WHERE hero.name =~ ".*SPIDER.*"
+RETURN hero.name as hero_name
+```
+
+or
+
+```cypher
+MATCH (hero: Hero)
+WHERE hero.name CONTAINS "SPIDER"
+RETURN hero.name as hero_name
 ```
 
 We recommend you search for your heroes of interest this way, which might save you
@@ -111,8 +116,8 @@ some time!
 
 ```cypher
 MATCH (:Hero {name: "SPIDER-MAN/PETER PARKER"})-[:AppearedIn]->(c:Comic)<-[:AppearedIn]-(:Hero {name: "VENOM/EDDIE BROCK"})
-RETURN c.name AS SpideyAndVenomComic
-ORDER BY SpideyAndVenomComic;
+RETURN c.name as comic
+ORDER BY comic
 ```
 
 4) List all the comic series in which Spider-Man/Peter Parker appears:
@@ -127,10 +132,7 @@ ORDER BY SpideySeries;
 
 ```cypher
 MATCH (:Hero {name: "SPIDER-MAN/PETER PARKER"})-[:AppearedIn]->(c:Comic)<-[:AppearedIn]-(h:Hero)
-WITH
-distinct(h) AS SpideyFriend,
-count(h) AS FriendCount
-RETURN SpideyFriend, FriendCount
+RETURN distinct(h) AS SpideyFriend, count(h) AS FriendCount
 ORDER BY FriendCount DESC
 LIMIT 10;
 ```


### PR DESCRIPTION
Consistency rules so far:
  - Cypher keywords have to be uppercase
  - if statements are containing only one query they need to be inline
  - never have `WITH` before `RETURN` (unless to avoid repeated calculation)
  - never use `WHERE` if you can do it in the `MATCH` statement

Feel free to argue for/against any rules so far and add new ones!