### PR TITLE
Added missing FROM keyword to LOAD CSV instructions

### DIFF
--- a/docs/database-functionalities/import-data.md
+++ b/docs/database-functionalities/import-data.md
@@ -461,7 +461,7 @@ The following query will load row by row from the file, and create a new node
 for each row with properties based on the parsed row values:
 
 ```cypher
-LOAD CSV "xyz.csv" WITH HEADER DELIMITER "|" AS row
+LOAD CSV FROM "xyz.csv" WITH HEADER DELIMITER "|" AS row
 CREATE (n:A {x: ToInteger(row.x), y: ToInteger(row.y), z: ToInteger(row.z)}) ; 
 ```
 
@@ -482,7 +482,7 @@ The following query will load row by row from the file, and create a new node
 for each row with properties based on the parsed row values:
 
 ```cypher
-LOAD CSV "xyz.csv" NO HEADER DELIMITER "|" AS row
+LOAD CSV FROM "xyz.csv" NO HEADER DELIMITER "|" AS row
 CREATE (n:A {x: ToInteger(row[0]), y: ToInteger(row[1]), z: ToInteger(row[2])}) ; 
   ```
 

--- a/memgraph_versioned_docs/version-1.4.0/database-functionalities/import-data.md
+++ b/memgraph_versioned_docs/version-1.4.0/database-functionalities/import-data.md
@@ -461,7 +461,7 @@ The following query will load row by row from the file, and create a new node
 for each row with properties based on the parsed row values:
 
 ```cypher
-LOAD CSV "xyz.csv" WITH HEADER DELIMITER "|" AS row
+LOAD CSV FROM "xyz.csv" WITH HEADER DELIMITER "|" AS row
 CREATE (n:A {x: ToInteger(row.x), y: ToInteger(row.y), z: ToInteger(row.z)}) ; 
 ```
 
@@ -482,7 +482,7 @@ The following query will load row by row from the file, and create a new node
 for each row with properties based on the parsed row values:
 
 ```cypher
-LOAD CSV "xyz.csv" NO HEADER DELIMITER "|" AS row
+LOAD CSV FROM "xyz.csv" NO HEADER DELIMITER "|" AS row
 CREATE (n:A {x: ToInteger(row[0]), y: ToInteger(row[1]), z: ToInteger(row[2])}) ; 
   ```
 


### PR DESCRIPTION
@g-despot This is a wild swing PR. Please double-check if it makes sense.
I was playing around with Memgraph Lab and it seems that the FROM keyword is missing from the LOAD CSV examples.