### PR TITLE
Rename overview pages

### DIFF
--- a/cypher-manual/overview.md
+++ b/cypher-manual/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Cypher manual
-sidebar_label: Overview
+sidebar_label: Cypher manual overview
 slug: /
 ---
 

--- a/docs/connect-to-memgraph/overview.md
+++ b/docs/connect-to-memgraph/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Overview
-sidebar_label: Overview
+sidebar_label: Connect to Memgraph overview
 slug: /connect-to-memgraph
 ---
 

--- a/docs/database-functionalities/overview.md
+++ b/docs/database-functionalities/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Database functionalities overview
-sidebar_label: Overview
+sidebar_label: Database functionalities overview
 slug: /database-functionalities
 ---
 

--- a/docs/database-functionalities/query-modules/overview.md
+++ b/docs/database-functionalities/query-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Query modules
-sidebar_label: Overview
+sidebar_label: Query modules overview
 slug: /database-functionalities/query-modules
 ---
 

--- a/docs/import-data/overview.md
+++ b/docs/import-data/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Import data
-sidebar_label: Overview
+sidebar_label: Import data overview
 slug: /import-data
 ---
 

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Install Memgraph
-sidebar_label: Overview
+sidebar_label: Install Memgraph overview
 slug: /installation
 ---
 

--- a/docs/reference-guide/overview.md
+++ b/docs/reference-guide/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Reference guide overview
-sidebar_label: Overview
+sidebar_label: Reference guide overview
 slug: /reference-guide
 ---
 

--- a/docs/reference-guide/query-modules/overview.md
+++ b/docs/reference-guide/query-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Query modules overview
-sidebar_label: Overview
+sidebar_label: Query modules overview
 slug: /reference-guide/query-modules
 ---
 

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Streams
-sidebar_label: Overview
+sidebar_label: Streams overview
 slug: /reference-guide/streams
 ---
 

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Transformation modules
-sidebar_label: Overview
+sidebar_label: Transformation modules overview
 slug: /reference-guide/streams/transformation-modules
 ---
 

--- a/docs/tutorials/overview.md
+++ b/docs/tutorials/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Tutorials
-sidebar_label: Overview
+sidebar_label: Tutorials overview
 slug: /tutorials
 ---
 

--- a/mage/overview.md
+++ b/mage/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: MAGE - Memgraph Advanced Graph Extensions 🔮
-sidebar_label: Overview
+sidebar_label: MAGE overview
 slug: /
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/connect-to-memgraph/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/connect-to-memgraph/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Overview
-sidebar_label: Overview
+sidebar_label: Connect to Memgraph overview
 slug: /connect-to-memgraph
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/database-functionalities/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/database-functionalities/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Database functionalities overview
-sidebar_label: Overview
+sidebar_label: Database functionalities overview
 slug: /database-functionalities
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/database-functionalities/query-modules/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/database-functionalities/query-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Query modules
-sidebar_label: Overview
+sidebar_label: Query modules overview
 slug: /database-functionalities/query-modules
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/import-data/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/import-data/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Import data
-sidebar_label: Overview
+sidebar_label: Import data overview
 slug: /import-data
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/installation/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/installation/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Install Memgraph
-sidebar_label: Overview
+sidebar_label: Install Memgraph overview
 slug: /installation
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/reference-guide/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/reference-guide/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Reference guide overview
-sidebar_label: Overview
+sidebar_label: Reference guide overview
 slug: /reference-guide
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/reference-guide/query-modules/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/reference-guide/query-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
-title: Query modules overview
-sidebar_label: Overview
+title: Query modules
+sidebar_label: Query modules overview
 slug: /reference-guide/query-modules
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/reference-guide/streams/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/reference-guide/streams/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Streams
-sidebar_label: Overview
+sidebar_label: Streams overview
 slug: /reference-guide/streams
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/reference-guide/streams/transformation-modules/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/reference-guide/streams/transformation-modules/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Transformation modules
-sidebar_label: Overview
+sidebar_label: Transformation modules overview
 slug: /reference-guide/streams/transformation-modules
 ---
 

--- a/memgraph_versioned_docs/version-1.6.1/tutorials/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/tutorials/overview.md
@@ -1,7 +1,7 @@
 ---
 id: overview
 title: Tutorials
-sidebar_label: Overview
+sidebar_label: Tutorials overview
 slug: /tutorials
 ---
 


### PR DESCRIPTION
Page names in the documentation hierarchy contain generic names like: "overview", "docker", and similar. This should be changed to "data import overview", "connect to Memgraph overview" and similar. The reason is the "step-by-step guide" we talked about. On the bottom of the page, the "next" article always shows the name of the next page. So for example, if you're positioned on the "connect to Memgraph" PHP page, the next page should be "import data overview", but it just says "overview".
I can make a pull request, but I'm unsure which files I need to change besides the actual file names of the pages.

Case in point: React Native documentation
The sub-menu is called "native modules", and the first page inside is called "native modules intro", not "intro".

Instead of modifying IDs and file names, I just changed the sidebar labels.