### PR TITLE
Add any to cypher-manual

### DIFF
--- a/cypher-manual/functions.md
+++ b/cypher-manual/functions.md
@@ -61,6 +61,7 @@ This section contains the list of supported functions.
  `toUpper`       | Returns the original string in uppercase.
  `trim`          | Returns the original string with leading and trailing whitespace removed.
  `all`           | Check if all elements of a list satisfy a predicate. The syntax is: `all(variable IN list WHERE predicate)`.<br/> NOTE: Whenever possible, use Memgraph's lambda functions when matching instead.
+ `any`           | Check if any element in the list satisfies the predicate. The syntax is: `any(element IN list WHERE predicate_using_element)`.
  `single`        | Check if only one element of a list satisfies a predicate. The syntax is: `single(variable IN list WHERE predicate)`.
  `reduce`        | Accumulate list elements into a single result by applying an expression. The syntax is: `reduce(accumulator = initial_value, variable IN list \| expression)`.
  `extract`       | A list of values obtained by evaluating an expression for each element in list. The syntax is: `extract(variable IN list \| expression)`.


### PR DESCRIPTION
Noticed that `any` is missing when answering [here](https://discourse.memgraph.com/t/returning-nodes-that-dont-have-a-certain-relationship) :smile: