### PR TITLE
update streaming docs

### DIFF
--- a/docs/database-functionalities/streams/implement-transformation-module.md
+++ b/docs/database-functionalities/streams/implement-transformation-module.md
@@ -4,7 +4,7 @@ title: Implement transformation modules
 sidebar_label: Implement transformation modules
 ---
 
-The prerequisite of connecting Memgraph to a Kafka stream is  to have a
+The prerequisite of connecting Memgraph to a Kafka stream is to have a
 transformation module that can produce Cypher queries based on the received
 messages. We are going to implement a simple transformation that stores the
 properties of each message in a vertex.
@@ -22,7 +22,7 @@ directory, even from the same module. Mounting a volume can be done by
 creating an empty directory `modules` and executing the following command:
 
 ```shell
-docker volume create --driver local --opt type=none  --opt device=modules --opt o=bind modules
+docker volume create --driver local --opt type=none --opt device=modules --opt o=bind modules
 ```
 
 Now, you can start Memgraph and mount the created volume:
@@ -61,6 +61,7 @@ following:
 ```python
 import mgp
 
+@mgp.transformation
 def my_transformation(context: mgp.TransCtx,
                       messages: mgp.Messages
                       ) -> mgp.Record(query=str, parameters=mgp.Nullable[mgp.Map]):
@@ -73,6 +74,7 @@ The transformations can slightly deviate from this by not receiving the
 ```python
 import mgp
 
+@mgp.transformation
 def my_transformation(messages: mgp.Messages
                       ) -> mgp.Record(query=str, parameters=mgp.Nullable[mgp.Map]):
     ...
@@ -93,6 +95,7 @@ We have to iterate over the messages and construct a query for each of them:
 ```python
 import mgp
 
+@mgp.transformation
 def my_transformation(messages: mgp.Messages
                       ) -> mgp.Record(query=str, parameters=mgp.Nullable[mgp.Map]):
     result_queries = []
@@ -116,6 +119,7 @@ with the properties, we can pass the properties as query parameters:
 ```python
 import mgp
 
+@mgp.transformation
 def my_transformation(messages: mgp.Messages
                       ) -> mgp.Record(query=str, parameters=mgp.Nullable[mgp.Map]):
     result_queries = []

--- a/docs/database-functionalities/streams/implement-transformation-module.md
+++ b/docs/database-functionalities/streams/implement-transformation-module.md
@@ -15,8 +15,8 @@ For detailed technical information on transformation modules, check out the [ref
 
 ## Using Docker with transformation modules
 
-If you are using Docker to run Memgraph you will have to create a volume
-and mount it to access the `query_modules` directory. Yes, `query_modules`,
+If you are using Docker to run Memgraph, you will have to create a volume
+and mount it to access the `query_modules` directory. Yes, `query_modules` ,
 because Memgraph can load transformations and query procedures from the same
 directory, even from the same module. Mounting a volume can be done by
 creating an empty directory `modules` and executing the following command:
@@ -68,8 +68,12 @@ def my_transformation(context: mgp.TransCtx,
     ...
 ```
 
+We also marked our function as a transformation so it will be recognized by
+Memgraph when the module is loaded. This was done by adding the
+`@mgp.transformation` decorator.
+
 The transformations can slightly deviate from this by not receiving the
-`context`, just the `messages`:
+`context` , just the `messages` :
 
 ```python
 import mgp
@@ -85,7 +89,7 @@ database, the `context` parameter is not necessary, so we are going to use the
 simpler version.
 
 The most important part is the actual implementation of the transformation
-function. Before showing how it can be done, let's clarify what is it
+function. Before showing how it can be done, let's clarify what it is
 supposed to do: it receives a list of messages and returns some queries and
 their parameters that will be executed in Memgraph as any regular query. Right,
 let's see how we can do that!
@@ -136,32 +140,8 @@ def my_transformation(messages: mgp.Messages
     return result_queries
 ```
 
-The `$timestamp`, `$payload` and `$topic` are the placeholders for parameters
+The `$timestamp` , `$payload` and `$topic` are the placeholders for parameters
 with the same name.
-
-Last, but not least we have to mark our function as a transformation so it will
-be recognized by Memgraph when the module is loaded. It can be done by adding
-the `@mgp.transformation` decorator to the function:
-
-```python
-import mgp
-
-@mgp.transformation
-def my_transformation(messages: mgp.Messages
-                      ) -> mgp.Record(query=str, parameters=mgp.Nullable[mgp.Map]):
-    result_queries = []
-
-    for i in range(messages.total_messages()):
-        message = messages.message_at(i)
-        payload_as_str = message.payload().decode("utf-8")
-        result_queries.append(mgp.Record(
-            query="CREATE (n:MESSAGE {timestamp: $timestamp, payload: $payload, topic: $topic})",
-            parameters={"timestamp": message.timestamp(),
-                        "payload": payload_as_str,
-                        "topic": message.topic_name()}))
-
-    return result_queries
-```
 
 Congratulations, you just created your first transformation procedure! To
 ensure that Memgraph can find the transformation, let's reload the modules:
@@ -196,13 +176,13 @@ compiled to the ELF shared library format.
 
 In this chapter, we assume that Memgraph is installed on a standard Debian or
 Ubuntu machine where the necessary header file can be found under
-`/usr/include/memgraph`. For other installations, the header file can be found
+`/usr/include/memgraph` . For other installations, the header file can be found
 under the `include/memgraph` folder in the Memgraph installation directory.
 
-As we already discussed how transformations work in the Python example we
+As we already discussed how transformations work in the Python example, we
 won't go over the transformation itself in detail. Also, to keep the
 complexity of this example low, this transformation doesn't use the query
-parameters. Apart from that this transformation does the same as the Python
+parameters. Apart from that, this transformation does the same as the Python
 example, but written in C++17.
 
 So let's create `c_transformation.cpp` and start to populate it!
@@ -278,7 +258,7 @@ clang++ --std=c++17 -Wall -shared -fPIC -I /home/kovi/data/memgraph/include c_tr
 ```
 
 After copying the resulting `c_transformation.so` to the
-`/usr/lib/memgraph/query_modules` directory we can reload the modules and check
+`/usr/lib/memgraph/query_modules` directory, we can reload the modules and check
 if Memgraph found our newly created transformation:
 
 ```cypher
@@ -302,5 +282,5 @@ You should see something like this:
 +----------------------------------------+
 ```
 
-For a more detailed overview check out the [Reference
+For a more detailed overview, check out the [Reference
 guide](/reference-guide/streams/transformation-modules/overview.md).

--- a/docs/database-functionalities/streams/kafka-streams.md
+++ b/docs/database-functionalities/streams/kafka-streams.md
@@ -4,13 +4,11 @@ title: Managing Kafka streams
 sidebar_label: Managing Kafka streams
 ---
 
-To connect Memgraph to a Kafka stream, we obviously need an existing stream.
-As Kafka itself is quite a complex system, we don't aim to teach you about
-it. If you are not familiar with Kafka, then please check out their [quickstart
+If you are not familiar with Kafka, then please check out their [quickstart
 guide](https://kafka.apache.org/quickstart) to get familiar. In the
-following, we assume that a Kafka server is available on the 9092 port of
+documentation, we assume that a Kafka server is available on the 9092 port of
 the local machine (`localhost:9092`) as the default configuration of the Kafka
-quick start guide.
+quick start guide. Please adjust your setup accordingly.
 
 :::tip
 Check out the **example-streaming-app** on [GitHub](https://github.com/memgraph/example-streaming-app) to see how Memgraph can be connected to a Kafka stream.
@@ -24,17 +22,15 @@ For detailed technical information on streaming support, check out the [referenc
 
 As Memgraph can connect to only one Kafka cluster at once, the list of
 bootstrap servers can be set by the `--kafka-bootstrap-servers`
-configuration option. It has to be set to `localhost:9092` (or to an
-arbitrary address where a Kafka cluster is available).
+configuration option. It has to be set explicitly.
 
 ## Creating the stream
 
-The very first step is to make sure at least one transformation is loaded into
-Memgraph. If you are not sure how to define them, you can find an example
-module
-[here](/database-functionalities/streams/implement-transformation-module.md).
+The very first step is to make sure at least one transformation module is loaded into
+Memgraph. If you are not sure how to define them, check out the
+[transformation module guide](/database-functionalities/streams/implement-transformation-module.md).
 We are going to use `transformation.my_transformation` from that example, but
-with the shorter `my.transform` name to make the size of result tables slimmer.
+we are going to alias it as `my.transform` to make the size of result tables slimmer.
 For the topic name, we are going to use the topic from the Kafka quick start,
 `quickstart-events`.
 
@@ -50,7 +46,11 @@ Check the created stream:
 SHOW STREAMS;
 ```
 
-The result should be like this:
+:::warning
+If you're running this in MemgraphLab an arbitrary error might happen. Please ignore it until we resolve the issue.
+:::
+
+The result should be similar to:
 
 ```plaintext
 +-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+-----------------------+

--- a/docs/database-functionalities/streams/kafka-streams.md
+++ b/docs/database-functionalities/streams/kafka-streams.md
@@ -47,7 +47,7 @@ SHOW STREAMS;
 ```
 
 :::warning
-If you're running this in MemgraphLab an arbitrary error might happen. Please ignore it until we resolve the issue.
+If you're running this in Memgraph Lab, an arbitrary error might happen. Please ignore it until we resolve the issue.
 :::
 
 The result should be similar to:

--- a/docs/reference-guide/security.md
+++ b/docs/reference-guide/security.md
@@ -148,3 +148,13 @@ such streams and triggers will fail because the lack of owner is treated as a
 user without any privileges, so no queries are allowed to be executed.
 - Currently, there is no way of changing the owner. The only workaround for this
 is to delete the stream or trigger and then create it again with another user.
+
+### Streams
+The user who executes the `CREATE STREAM` query is going to be the owner of the stream.
+Authentication and authorization are not supported in Memgraph Community, thus
+the owner will always be `Null`, and the privileges are not checked in Memgraph
+Community. In Memgraph Enterprise the privileges of the owner are used when
+executing the queries returned from a transformation, in other words, the
+execution of the queries will fail if  the owner doesn't have the required
+privileges. More information about how the owner affects the stream can be
+found in the

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -34,7 +34,7 @@ stream name|Name of the stream in Memgraph|string|my_stream|/
 topic|Name of the topic in Kafka|string|my_topic|/
 transform procedure|Name of the transformation file followed by a function name|function|my_transformation.my_transform|/
 consumer group|Name of the consumer group in Memgraph|string|my_group|mg_consumer
-batch interval duration|Maximum wait time for consuming messages before calling the transform procedure|int|9999|100
+batch interval duration|Maximum wait time in milliseconds for consuming messages before calling the transform procedure|int|9999|100
 batch size|Maximum number of messages to wait for before calling the transform procedure|int|99|1000
 
 The transformation procedure is called if either the `BATCH_INTERVAL` or the

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -30,10 +30,10 @@ CREATE STREAM <stream name>
 
 option|description|type|example|default
 :-:|:-:|:-:|:-:|:-:
-stream name|Name of the stream in Memgraph|string|my_stream|/
-topic|Name of the topic in Kafka|string|my_topic|/
+stream name|Name of the stream in Memgraph|plain text|my_stream|/
+topic|Name of the topic in Kafka|plain text|my_topic|/
 transform procedure|Name of the transformation file followed by a function name|function|my_transformation.my_transform|/
-consumer group|Name of the consumer group in Memgraph|string|my_group|mg_consumer
+consumer group|Name of the consumer group in Memgraph|plain text|my_group|mg_consumer
 batch interval duration|Maximum wait time in milliseconds for consuming messages before calling the transform procedure|int|9999|100
 batch size|Maximum number of messages to wait for before calling the transform procedure|int|99|1000
 

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -6,16 +6,13 @@ slug: /reference-guide/streams
 ---
 
 Memgraph can connect to existing Kafka streams. To use streams, a user
-must
-- Manage a stream via a query
-- Provide a user-defined transformation module
-
-More information about transformation modules can be found
-**[here](/reference-guide/streams/transformation-modules/overview.md)**.
-The rest of this section describes how to manage streams with Memgraph.
+must:
+1. [**create a transformation module**](/reference-guide/streams/transformation-modules/overview.md)
+2. create the stream with a `CREATE STREAM` query
+3. start the stream with a `START STREAM` query
 
 :::tip
-Check out the **example-streaming-app** on [GitHub](https://github.com/memgraph/example-streaming-app) to see how Memgraph can be connected to a Kafka stream.
+Check out the **example-streaming-app** on [GitHub](https://github.com/memgraph/example-streaming-app) to see a sample Memgraph-Kafka application.
 :::
 
 ## Creating a stream
@@ -26,40 +23,27 @@ The general syntax for creating a stream is:
 CREATE STREAM <stream name>
   TOPICS <topic1> [, <topic2>, ...]
   TRANSFORM <transform procedure>
-  [CONSUMER_GROUP <consumer group name>]
-  [BATCH_INTERVAL <milliseconds>]
-  [BATCH_SIZE <size>];
+  [CONSUMER_GROUP <consumer group>]
+  [BATCH_INTERVAL <batch interval length>]
+  [BATCH_SIZE <batch size>];
 ```
-Create a `STREAM` with name `<stream name>` that consumes messages from
-`TOPICS` with name `<topic1>` and `<topic2>`. `TRANSFORM` denotes the user-defined
-transformation with name `<transform procedure>`.
 
-Additionally, the user can provide the following optional parameters:
-- `CONSUMER_GROUP` with name `<consumer group name>`. If not specified, then
-`mg_consumer` will be used as a consumer group name.
-- `BATCH_INTERVAL` denotes the maximum wait time interval for consuming message(s)
-before calling the transformation procedure with the already received message(s).
-This value must be greater than zero and is defaulted to 100.
-- `BATCH_SIZE` denotes the total number of messages to wait before calling
-the transformation procedure with the already received message(s).
-It must be greater than zero and is defaulted to 1000.
+option|description|type|example|default
+:-:|:-:|:-:|:-:|:-:
+stream name|Name of the stream in Memgraph|string|my_stream|/
+topic|Name of the topic in Kafka|string|my_topic|/
+transform procedure|Name of the transformation file followed by a function name|function|my_transformation.my_transform|/
+consumer group|Name of the consumer group in Memgraph|string|my_group|mg_consumer
+batch interval duration|Maximum wait time for consuming messages before calling the transform procedure|int|9999|100
+batch size|Maximum number of messages to wait for before calling the transform procedure|int|99|1000
 
 The transformation procedure is called if either the `BATCH_INTERVAL` or the
 `BATCH_SIZE` is reached and there is at least one received message.
+
 The `BATCH_INTERVAL` starts when the:
 - the stream is started
 - the processing of the previous batch is completed
 - the previous batch interval ended without receiving any messages
-
-The user who executes the `CREATE` query is going to be the owner of the stream.
-Authentication and authorization are not supported in Memgraph Community, thus
-the owner will always be `Null`, and the privileges are not checked in Memgraph
-Community. In Memgraph Enterprise the privileges of the owner are used when
-executing the queries returned from a transformation, in other words, the
-execution of the queries will fail if  the owner doesn't have the required
-privileges. More information about how the owner affects the stream can be
-found in the
-[reference guide](reference-guide/security.md#owners).
 
 ## Deleting a stream
 
@@ -79,31 +63,6 @@ Starts a stream (or all streams) with name `<stream name>`.
 When a stream is started, it should resume from the last committed offset. If
 there is no committed offset for the consumer group, then the largest offset
 will be used, therefore only the new messages will be consumed.
-
-### At least once semantics
-
-In stream processing, it is important to have some guarantees about how failures
-are handled. When connecting an external application such as Memgraph to a
-Kafka stream, there are two possible ways to handle failures during message
-processing:
-1. Every message is processed **at least once**: the message offsets are
-committed to the Kafka cluster after the processing is done. This means if the
-committing fails, then the messages can get processed multiple times.
-2. Every message is processed **at most once**: the message offsets are
-committed to the Kafka cluster right after they are received before the
-processing is started. This means if the processing fails, then the same
-messages won't be processed again.
-
-Missing a message can result in missing an edge that would connect two
-independent components of the graph. Therefore, we think that missing
-some information is a bigger problem for graphs than having some information
-duplicated, so we implemented our streams using the **at least once**
-semantics, i.e. for every batch of messages the queries returned by the
-transformations are executed and committed to the database before committing
-the message offset to the Kafka cluster. However, even though we cannot guarantee **exactly
-once** semantics, we tried to minimize the possibility of processing messages
-multiple times. This means committing the message offsets to the Kafka cluster
-happens right after the transaction is committed to the database.
 
 ## Stop a stream
 
@@ -144,3 +103,28 @@ messages.
 `TIMEOUT` is measured in milliseconds, and it's defaulted to 30000.
 
 Checking a stream won't commit any offsets.
+
+## At least once semantics
+
+In stream processing, it is important to have some guarantees about how failures
+are handled. When connecting an external application such as Memgraph to a
+Kafka stream, there are two possible ways to handle failures during message
+processing:
+1. Every message is processed **at least once**: the message offsets are
+committed to the Kafka cluster after the processing is done. This means if the
+committing fails, then the messages can get processed multiple times.
+2. Every message is processed **at most once**: the message offsets are
+committed to the Kafka cluster right after they are received before the
+processing is started. This means if the processing fails, then the same
+messages won't be processed again.
+
+Missing a message can result in missing an edge that would connect two
+independent components of the graph. Therefore, we think that missing
+some information is a bigger problem for graphs than having some information
+duplicated, so we implemented our streams using the **at least once**
+semantics, i.e. for every batch of messages the queries returned by the
+transformations are executed and committed to the database before committing
+the message offset to the Kafka cluster. However, even though we cannot guarantee **exactly
+once** semantics, we tried to minimize the possibility of processing messages
+multiple times. This means committing the message offsets to the Kafka cluster
+happens right after the transaction is committed to the database.

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -7,9 +7,9 @@ slug: /reference-guide/streams
 
 Memgraph can connect to existing Kafka streams. To use streams, a user
 must:
-1. [**create a transformation module**](/reference-guide/streams/transformation-modules/overview.md)
-2. create the stream with a `CREATE STREAM` query
-3. start the stream with a `START STREAM` query
+1. [**Create a transformation module**](/reference-guide/streams/transformation-modules/overview.md)
+2. Create the stream with a `CREATE STREAM` query
+3. Start the stream with a `START STREAM` query
 
 :::tip
 Check out the **example-streaming-app** on [GitHub](https://github.com/memgraph/example-streaming-app) to see a sample Memgraph-Kafka application.
@@ -38,12 +38,21 @@ batch interval duration|Maximum wait time in milliseconds for consuming messages
 batch size|Maximum number of messages to wait for before calling the transform procedure|int|99|1000
 
 The transformation procedure is called if either the `BATCH_INTERVAL` or the
-`BATCH_SIZE` is reached and there is at least one received message.
+`BATCH_SIZE` is reached, and there is at least one received message.
 
 The `BATCH_INTERVAL` starts when the:
 - the stream is started
 - the processing of the previous batch is completed
 - the previous batch interval ended without receiving any messages
+
+The user who executes the `CREATE` query is going to be the owner of the stream.
+Authentication and authorization are not supported in Memgraph Community, thus
+the owner will always be `Null`, and the privileges are not checked in Memgraph
+Community. In Memgraph Enterprise, the privileges of the owner are used when
+executing the queries returned from a transformation. In other words, the
+execution of the queries will fail if  the owner doesn't have the required
+privileges. More information about how the owner affects the stream can be found
+in the [reference guide](reference-guide/security.md#owners).
 
 ## Deleting a stream
 
@@ -62,7 +71,7 @@ Starts a stream (or all streams) with name `<stream name>`.
 
 When a stream is started, it should resume from the last committed offset. If
 there is no committed offset for the consumer group, then the largest offset
-will be used, therefore only the new messages will be consumed.
+will be used. Therefore only the new messages will be consumed.
 
 ## Stop a stream
 

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -6,9 +6,9 @@ slug: /reference-guide/streams/transformation-modules
 ---
 
 In order to create a transformation module, you need to:
-1. Create a [python](./api/python-api.md) or a [shared library](./api/c-api.md) file (module)
-2. Save it into the Memgraph's `query-modules` directory, default: `/usr/lib/memgraph/query_modules`
-3. Load it into Memgraph either on start up (automatically), or by running a `CALL mg.load` query
+1. Create a [Python](./api/python-api.md) or a [shared library](./api/c-api.md) file (module)
+2. Save it into the Memgraph's `query-modules` directory (default: `/usr/lib/memgraph/query_modules`)
+3. Load it into Memgraph either on startup (automatically) or by running a `CALL mg.load` query
 
 Memgraph supports user-defined transformations in **C** and **Python**
 that act on data received from a streaming engine. These transformations
@@ -18,7 +18,7 @@ query procedure, or both.
 
 This section introduces transformation modules and their similarities
 with query modules. Currently, we only support transformations for
-Kafka streams but we are aiming to add support for other
+Kafka streams, but we are aiming to add support for other
 streaming engines as well.
 
 The available API references are:
@@ -42,22 +42,21 @@ will be mapped to the `py_hello` module.
 If you want to change the directory in which Memgraph searches for
 transformation modules, just change or extend the `--query-modules-directory`
 flag in the main configuration file (`/etc/memgraph/memgraph.conf`) or supply
-it as a command-line parameter (e.g. when using Docker).
+it as a command-line parameter (e.g., when using Docker).
 
 ## Utility procedures for transformations
 
 Query procedures that allow the users to gain more insight into other modules and
 transformations are written under our utility `mg` query module.
-For transformations this module offers:
+For transformations, this module offers:
 
-procedure|description
-:-:|:-:
-`mg.transformations() :: (name :: STRING)`|Lists all transformations
-  procedures.
-`mg.load(module_name :: STRING) :: ()`|Loads or reloads the given module.
-`mg.load_all() :: ()`|Loads or reloads all modules.
+|procedure|description|
+|---------|-----------|
+|`mg.transformations() :: (name :: STRING)`|Lists all transformations procedures.|
+|`mg.load(module_name :: STRING) :: ()`|Loads or reloads the given module.|
+|`mg.load_all() :: ()`|Loads or reloads all modules.|
 
-For example, you can invoke `mg.transformations()` from mgconsole/MemgraphLab with the following command:
+For example, you can invoke `mg.transformations()` from mgconsole or Memgraph Lab with the following command:
 
 ```cypher
 CALL mg.transformations() YIELD *;

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -6,7 +6,7 @@ slug: /reference-guide/streams/transformation-modules
 ---
 
 In order to create a transformation module, you need to:
-1. Create a [python](./api/python-api.md) or a [c](./api/c-api.md) file (module)
+1. Create a [python](./api/python-api.md) or a [shared library](./api/c-api.md) file (module)
 2. Save it into the Memgraph's `query-modules` directory, default: `/usr/lib/memgraph/query_modules`
 3. Load it into Memgraph either on start up (automatically), or by running a `CALL mg.load` query
 

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -5,6 +5,11 @@ sidebar_label: Transformation modules overview
 slug: /reference-guide/streams/transformation-modules
 ---
 
+In order to create a transformation module, you need to:
+1. Create a [python](./api/python-api.md) or a [c](./api/c-api.md) file (module)
+2. Save it into the Memgraph's `query-modules` directory, default: `/usr/lib/memgraph/query_modules`
+3. Load it into Memgraph either on start up (automatically), or by running a `CALL mg.load` query
+
 Memgraph supports user-defined transformations in **C** and **Python**
 that act on data received from a streaming engine. These transformations
 are grouped into modules called **Transformation modules** which can then
@@ -32,7 +37,7 @@ The `*.so` modules are written using the C API and the `*.py` modules are
 written using the Python API. Each file corresponds to one module. Names
 of these files will be mapped to module names.  For example, `hello.so`
 will be mapped to the `hello` module and a `py_hello.py` script
-will be mapped to the `py_hello.py` module.
+will be mapped to the `py_hello` module.
 
 If you want to change the directory in which Memgraph searches for
 transformation modules, just change or extend the `--query-modules-directory`
@@ -45,18 +50,20 @@ Query procedures that allow the users to gain more insight into other modules an
 transformations are written under our utility `mg` query module.
 For transformations this module offers:
 
-* `mg.transformations() :: (name :: STRING)`: Lists all transformations
+procedure|description
+:-:|:-:
+`mg.transformations() :: (name :: STRING)`|Lists all transformations
   procedures.
-* `mg.load(module_name :: STRING) :: ()`: Loads or reloads the given module.
-* `mg.load_all() :: ()`: Loads or reloads all modules.
+`mg.load(module_name :: STRING) :: ()`|Loads or reloads the given module.
+`mg.load_all() :: ()`|Loads or reloads all modules.
 
-For example, invoking `mg.transformations()` from openCypher like so:
+For example, you can invoke `mg.transformations()` from mgconsole/MemgraphLab with the following command:
 
 ```cypher
 CALL mg.transformations() YIELD *;
 ```
 
-might yield the following result:
+This will yield the following result:
 
 ```plaintext
 +---------------------+


### PR DESCRIPTION
- [x] reference guide/streams/overview
- [x] reference guide/streams/transformation-modules/overview
- [x] database functionalities/streams/implement-transformation-module
- [x] database functionalities/streams/kafka-streams

The general idea of this PR is to reduce verbosity, and condense the documentation to a succinct form that is pleasant to read and navigate through.