### PR TITLE
Transfer subdomain to subdirectory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,9 +83,9 @@ website](https://docusaurus.io/docs/versioning).
   headings** with random uppercase letters.
 - The first file in each subdirectory should be the **overview.md** file, and it
   should indicate what the directory contains (for example, the [Query
-  modules](https://docs.memgraph.com/memgraph/reference-guide/query-modules)
+  modules](https://memgraph.com/docs/memgraph/reference-guide/query-modules)
   section). This is not always the best solution (the [OS
-  installation](https://docs.memgraph.com/memgraph/install-memgraph-on-linux-docker)
+  installation](https://memgraph.com/docs/memgraph/install-memgraph-on-linux-docker)
   sections), but it makes it easier for users to explore unknown
   functionalities. If you think that in your case, it's not needed and would do
   more harm than good, ask the DevRel team for help.
@@ -111,7 +111,7 @@ At the beginning of each markdown file, you can add the following fields:
   to define them explicitly for **overview.md** files. For example, the default
   URL for the file `/memgraph/reference-guide/query-modules/overview.md`  would
   be
-  [docs.memgraph.com/memgraph/reference-guide/query-modules/overview](http://docs.memgraph.com/memgraph/reference-guide/query-modules/overview),
+  [memgraph.com/docs/memgraph/reference-guide/query-modules/overview](http://memgraph.com/docs/memgraph/reference-guide/query-modules/overview),
   but it would make more sense to omit the *overview* part at the end.
 
 ## Changing and redirecting URLs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [docs.memgraph.com](http://docs.memgraph.com/)
+# [memgraph.com/docs](http://memgraph.com/docs/)
 [![PRs
 Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/memgraph/docs/blob/master/CONTRIBUTING.md)
 ![Build
@@ -9,7 +9,7 @@ alt="Follow @memgraphdb" /></a>
 
 This repository contains the source files and various generators for the
 Memgraph documentation available at
-[docs.memgraph.com](https://docs.memgraph.com). Since we are writing our
+[memgraph.com/docs](https://memgraph.com/docs). Since we are writing our
 technical documentation using markdown, it is also nicely rendered by GitHub, as
 you can see by following [this
 link](https://github.com/memgraph/docs/blob/master/docs/overview.md).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,9 +1,9 @@
-const baseUrl = '/';
+const baseUrl = '/docs/';
 
 module.exports = {
   title: 'Memgraph Docs',
   tagline: 'Welcome to the Memgraph Docs site!',
-  url: 'https://docs.memgraph.com',
+  url: 'https://docusaurus.memgraph.com',
   baseUrl,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -16,8 +16,8 @@ module.exports = {
   ],
   scripts: [
     {
-      src: `https://docs.memgraph.com/js/load-analytics.js`,
-      //src: `http://localhost:3000/js/load-analytics.js`,
+      src: `https://memgraph.com/docs/js/load-analytics.js`,
+      // src: `http://localhost:3000/docs/js/load-analytics.js`,
     },
     {
       src: 'https://kit.fontawesome.com/3a9f2eb5b9.js'

--- a/lab/style-script/quick-start.md
+++ b/lab/style-script/quick-start.md
@@ -11,7 +11,7 @@ complete list available features consult
 ## Graph example
 
 In this guide, we will use an example graph with European countries and cities. 
-The data can be found [here](https://docs.memgraph.com/memgraph/tutorials-overview/backpacking-through-europe).
+The data can be found [here](https://memgraph.com/docs/memgraph/tutorials-overview/backpacking-through-europe).
 Countries have the label `Country`, while cities have the label `City`. All 
 nodes have the property `name`. Cities have many additional properties, 
 including `country` (containing country) and `drinks_USD` (average drink price).

--- a/mage/overview.md
+++ b/mage/overview.md
@@ -23,7 +23,7 @@ Memgraph introduces the concept of **query modules**, user-defined procedures
 that extend the **Cypher query language**. These procedures are grouped into
 modules that can be loaded into Memgraph. You can find more information on query
 modules in the official [Memgraph
-documentation](https://docs.memgraph.com/memgraph/database-functionalities/query-modules/built-in-query-modules).
+documentation](https://memgraph.com/docs/memgraph/database-functionalities/query-modules/built-in-query-modules).
 
 ## Spellbook 📖 - Currently available modules
 

--- a/memgraph_versioned_sidebars/version-1.3.0-sidebars.json
+++ b/memgraph_versioned_sidebars/version-1.3.0-sidebars.json
@@ -48,7 +48,7 @@
             {
               "type": "link",
               "label": "Memgraph Lab",
-              "href": "https://docs.memgraph.com/memgraph-lab"
+              "href": "https://memgraph.com/docs/memgraph-lab"
             },
             {
               "type": "link",

--- a/memgraph_versioned_sidebars/version-1.4.0-sidebars.json
+++ b/memgraph_versioned_sidebars/version-1.4.0-sidebars.json
@@ -29,7 +29,7 @@
             {
               "type": "link",
               "label": "Memgraph Lab",
-              "href": "https://docs.memgraph.com/memgraph-lab"
+              "href": "https://memgraph.com/docs/memgraph-lab"
             },
             {
               "type": "link",

--- a/memgraph_versioned_sidebars/version-1.5.0-sidebars.json
+++ b/memgraph_versioned_sidebars/version-1.5.0-sidebars.json
@@ -29,7 +29,7 @@
             {
               "type": "link",
               "label": "Memgraph Lab",
-              "href": "https://docs.memgraph.com/memgraph-lab"
+              "href": "https://memgraph.com/docs/memgraph-lab"
             },
             {
               "type": "link",

--- a/memgraph_versioned_sidebars/version-1.6.0-sidebars.json
+++ b/memgraph_versioned_sidebars/version-1.6.0-sidebars.json
@@ -105,7 +105,7 @@
             {
               "type": "link",
               "label": "Memgraph Lab",
-              "href": "https://docs.memgraph.com/memgraph-lab"
+              "href": "https://memgraph.com/docs/memgraph-lab"
             },
             {
               "type": "doc",

--- a/memgraph_versioned_sidebars/version-1.6.1-sidebars.json
+++ b/memgraph_versioned_sidebars/version-1.6.1-sidebars.json
@@ -101,7 +101,7 @@
             {
               "type": "link",
               "label": "Memgraph Lab",
-              "href": "https://docs.memgraph.com/memgraph-lab"
+              "href": "https://memgraph.com/docs/memgraph-lab"
             },
             {
               "type": "doc",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "docs",
+  "homepage": "/docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/sidebars/sidebarsMemgraph.js
+++ b/sidebars/sidebarsMemgraph.js
@@ -50,7 +50,7 @@ module.exports = {
             {
               type: "link",
               label: "Memgraph Lab",
-              href: "https://docs.memgraph.com/memgraph-lab",
+              href: "https://memgraph.com/docs/memgraph-lab",
             },
             "connect-to-memgraph/methods/drivers",
             {

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-docs.memgraph.com
+docusaurus.memgraph.com


### PR DESCRIPTION
Relevant blog post explanation is in notion under engineering/general/website setup. *TODO* update this reference when the blog post gets published.

Tasks:
- [x] Docusaurus config (`baseUrl`: `/docs`)
- [x] package.json config (homepage)
- [x] all mentions of docs.memgraph.com -> memgraph.com/docs
- [x] change CNAME to docusaurus.memgraph.com