### PR TITLE
fix wrong urls

### DIFF
--- a/docs/import-data/kafka/overview.md
+++ b/docs/import-data/kafka/overview.md
@@ -69,7 +69,7 @@ extend the `--query-modules-directory` flag in the main configuration file
 when using Docker).
 
 Check [this
-guide](https://docs.memgraph.com/memgraph/database-functionalities/streams/implement-transformation-module/#python-api)
+guide](/memgraph/database-functionalities/streams/implement-transformation-module/#python-api)
 for an example of how to implement transformation modules in Python.
 
 Load the transformation module from `/usr/lib/memgraph/query_modules` by using
@@ -100,7 +100,7 @@ You should see an output similar to the following:
 
 Creating, starting, and deleting the streams can be done with Cypher queries.
 The list of available stream commands can be found
-[here](https://docs.memgraph.com/memgraph/reference-guide/streams/).
+[here](/memgraph/reference-guide/streams/).
 
 To import data, first, make sure Kafka and Memgraph are running and there is a
 topic available.

--- a/memgraph_versioned_docs/version-1.6.1/import-data/kafka/overview.md
+++ b/memgraph_versioned_docs/version-1.6.1/import-data/kafka/overview.md
@@ -69,7 +69,7 @@ extend the `--query-modules-directory` flag in the main configuration file
 when using Docker).
 
 Check [this
-guide](https://docs.memgraph.com/memgraph/database-functionalities/streams/implement-transformation-module/#python-api)
+guide](/memgraph/database-functionalities/streams/implement-transformation-module/#python-api)
 for an example of how to implement transformation modules in Python.
 
 Load the transformation module from `/usr/lib/memgraph/query_modules` by using
@@ -100,7 +100,7 @@ You should see an output similar to the following:
 
 Creating, starting, and deleting the streams can be done with Cypher queries.
 The list of available stream commands can be found
-[here](https://docs.memgraph.com/memgraph/reference-guide/streams/).
+[here](/memgraph/reference-guide/streams/).
 
 To import data, first, make sure Kafka and Memgraph are running and there is a
 topic available.


### PR DESCRIPTION
Some new `docs.memgraph.com` links emerged. We should be more careful about those when accepting pull requests.