### PR TITLE
Fix typo in subtitle

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@ sidebar_label: Changelog
 
 * Added support for parameters with `CREATE` clause in the following form: `CREATE (n $param)`.
 * Added writeable procedure support, so
-  [procedures](database-functionalities/query-modules/implement-query-modules#writeable-procedures)
+  [procedures](database-functionalities/query-modules/implement-query-modules)
   can modify the graph by creating and deleting vertices and edges, modifying
   the labels of vertices or setting the properties of vertices and edges.
 

--- a/docs/database-functionalities/query-modules/implement-query-modules.md
+++ b/docs/database-functionalities/query-modules/implement-query-modules.md
@@ -148,7 +148,7 @@ return mgp.Record(args=args_copy, vertex_count=vertex_count,
                   avg_degree=avg_degree, props=props)
 ```
 
-### Writeable procedure
+### Writeable procedures
 
 Writeable procedures can be implemented in a very similar way as read-only
 procedures. The only difference is writeable procedures receive mutable objects,


### PR DESCRIPTION
Apart from fixing the typo I removed the reference to the subtitle on the changelog page because I couldn't make it work (to jump right to the subtitle).