### PR TITLE
[release-2.1 < T0762-MG] Add kafka set stream offset docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ sidebar_label: Changelog
 
 * Now supporting Bolt protocol version 4.3. [#228](https://github.com/memgraph/memgraph/pull/226)
 * Streams support for retrying conflicting transactions [#294](https://github.com/memgraph/memgraph/pull/294)
+* Added procedure to configure the starting offset (to consume messages from) of a topic (and its partitions). [#282](https://github.com/memgraph/memgraph/pull/282)
 
 ### Bug Fixes
 

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -181,7 +181,7 @@ option|description|type|example|default
 stream name|Name of the stream to set the offset|string|"my_stream"|/
 offset|Offset number to set|int|0|/
 
-An offset of `-1` denotes the start of the stream i.e, offset 0.
+An offset of `-1` denotes the start of the stream i.e, the beginning offset available for the given topic/partition
 An offset of `-2` denotes the end of the stream i.e, for each topic/partition, its logical end such that
 only the next produced message will be consumed.
 

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -11,7 +11,8 @@ Memgraph can connect to existing Kafka streams. To use streams, a user must:
 2. [Configure Memgraph](/reference-guide/configuration.md) to connect to, e.g.
    Kafka, by providing the appropriate flag
    `--kafka-bootstrap-servers=localhost:9092`
-3. [Create the stream](#creating-a-stream) with a `CREATE STREAM` query
+3. [Create the stream](#creating-a-stream) with a `CREATE STREAM` query and optionally 
+   [set its offset](#setting-a-stream-offset) with a `CALL mg.kafka_set_stream_offset(stream_name, offset)`
 4. [Start the stream](#start-a-stream) with a `START STREAM` query
 
 :::tip Check out the **example-streaming-app** on
@@ -164,4 +165,26 @@ Moreover, the interval of retries is also important and can be configured by
 ```
 --stream-transaction-retry-interval=INTERVAL_TIME
 ```
+
 The `INTERVAL_TIME` is measured in `milliseconds` and its default value is `500ms`.
+## Setting a stream offset
+
+For Kafka streams users can manually set the offset of the next consumed message 
+with a call to the query procedure `mg.kafka_set_stream_offset`
+
+```cypher
+CALL mg.kafka_set_stream_offset(stream_name, offset)
+```
+
+option|description|type|example|default
+:-:|:-:|:-:|:-:|:-:
+stream name|Name of the stream to set the offset|string|"my_stream"|/
+offset|Offset number to set|int|0|/
+
+An offset of `-1` denotes the start of the stream i.e, offset 0.
+An offset of `-2` denotes the end of the stream i.e, for each topic/partition, its logical end such that
+only the next produced message will be consumed.
+
+Note, that a stream can consume from multiple topics each of them having multiple partitions. Therefore, 
+when setting the offsets to an arbitrary number the user must be cautious that
+setting the offset of a stream internally sets all of the associated offsets of that stream(topics/partitions) to that value.

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -12,7 +12,7 @@ Memgraph can connect to existing Kafka streams. To use streams, a user must:
    Kafka, by providing the appropriate flag
    `--kafka-bootstrap-servers=localhost:9092`
 3. [Create the stream](#creating-a-stream) with a `CREATE STREAM` query and optionally 
-   [set its offset](#setting-a-stream-offset) with a `CALL mg.kafka_set_stream_offset(stream_name, offset)`
+   [set its offset](#setting-a-stream-offset) with `CALL mg.kafka_set_stream_offset(stream_name, offset)`
 4. [Start the stream](#start-a-stream) with a `START STREAM` query
 
 :::tip Check out the **example-streaming-app** on

--- a/docs/reference-guide/streams/overview.md
+++ b/docs/reference-guide/streams/overview.md
@@ -11,7 +11,7 @@ Memgraph can connect to existing Kafka streams. To use streams, a user must:
 2. [Configure Memgraph](/reference-guide/configuration.md) to connect to, e.g.
    Kafka, by providing the appropriate flag
    `--kafka-bootstrap-servers=localhost:9092`
-3. [Create the stream](#creating-a-stream) with a `CREATE STREAM` query and optionally 
+3. [Create the stream](#creating-a-stream) with a `CREATE STREAM` query and optionally
    [set its offset](#setting-a-stream-offset) with `CALL mg.kafka_set_stream_offset(stream_name, offset)`
 4. [Start the stream](#start-a-stream) with a `START STREAM` query
 
@@ -169,8 +169,8 @@ Moreover, the interval of retries is also important and can be configured by
 The `INTERVAL_TIME` is measured in `milliseconds` and its default value is `500ms`.
 ## Setting a stream offset
 
-For Kafka streams users can manually set the offset of the next consumed message 
-with a call to the query procedure `mg.kafka_set_stream_offset`
+For Kafka streams, users can manually set the offset of the next consumed
+message with a call to the query procedure `mg.kafka_set_stream_offset` :
 
 ```cypher
 CALL mg.kafka_set_stream_offset(stream_name, offset)
@@ -181,10 +181,13 @@ option|description|type|example|default
 stream name|Name of the stream to set the offset|string|"my_stream"|/
 offset|Offset number to set|int|0|/
 
-An offset of `-1` denotes the start of the stream i.e, the beginning offset available for the given topic/partition
-An offset of `-2` denotes the end of the stream i.e, for each topic/partition, its logical end such that
-only the next produced message will be consumed.
+* An offset of `-1` denotes the start of the stream, i.e., the beginning offset
+  available for the given topic/partition.
+* An offset of `-2` denotes the end of the stream, i.e., for each
+  topic/partition, its logical end such that only the next produced message will
+  be consumed.
 
-Note, that a stream can consume from multiple topics each of them having multiple partitions. Therefore, 
-when setting the offsets to an arbitrary number the user must be cautious that
-setting the offset of a stream internally sets all of the associated offsets of that stream(topics/partitions) to that value.
+Note, that a stream can consume from multiple topics each of them having
+multiple partitions. Therefore, when setting the offsets to an arbitrary number
+the user must be cautious that setting the offset of a stream internally sets
+all of the associated offsets of that stream (topics/partitions) to that value.


### PR DESCRIPTION
Original PR is #240 was merged, but I used simple merge instead of squash merge. I force-pushed `release-2.1` to revert the merge.