### PR TITLE
Change footer link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -222,7 +222,7 @@ module.exports = {
           items: [
             {
               label: "Memgraph",
-              to: "/memgraph/getting-started",
+              to: "/memgraph",
             },
             {
               label: "Memgraph Lab",


### PR DESCRIPTION
Redirect /memgraph/getting-started -> /memgraph/ didn't work when clicking on footer Memgraph link