### PR TITLE
[master < T0658-DX] Change query modules directory name

### DIFF
--- a/docs/reference-guide/configuration.md
+++ b/docs/reference-guide/configuration.md
@@ -33,7 +33,7 @@ Each configuration setting is in the form: `--setting-name=value` .
 | --query-cost-planner=true | Use the cost-estimating query planner. | `[bool]` |
 | --query-execution-timeout-sec=180 | Maximum allowed query execution time. <br/>Queries exceeding this limit will be aborted. Value of 0 means no limit. | `[uint64]` |
 | --query-max-plans=1000 | Maximum number of generated plans for a query. | `[uint64]` |
-| --query-modules-directory=/usr/lib/memgraph/query-modules | Directory where modules with custom query procedures are stored. NOTE: Multiple comma-separated directories can be defined. | `[string]` |
+| --query-modules-directory=/usr/lib/memgraph/query_modules | Directory where modules with custom query procedures are stored. NOTE: Multiple comma-separated directories can be defined. | `[string]` |
 | --query-plan-cache-ttl=60 | Time to live for cached query plans, in seconds. | `[int32]` |
 | --query-vertex-count-to-expand-existing=10 | Maximum count of indexed vertices which provoke indexed lookup and then expand to existing, <br/>instead of a regular expand. Default is 10, to turn off use -1. | `[int64]` |
 


### PR DESCRIPTION
**Description**
Just changed the directory name in config settings for `--query-modules-directory` flag from `query-modules` to `query_modules`.

Closes https://github.com/memgraph/docs/issues/369