### PR TITLE
[master < T0714-DX] Link Docker how-to from existing docs

### DIFF
--- a/docs/how-to-guides/overview.md
+++ b/docs/how-to-guides/overview.md
@@ -114,7 +114,7 @@ custom-built external auth module. To learn more visit:
 If you are new to Docker, this how-to guide will help you get a grasp of Docker and
 make it easier to accomplish tasks within Memgraph:
 
-- [Work with Docker](/memgraph/how-to-work-with-docker)
+- [Work with Docker](/how-to-guides/work-with-docker.md)
 
 
 ## Triggers

--- a/docs/how-to-guides/work-with-docker.md
+++ b/docs/how-to-guides/work-with-docker.md
@@ -2,7 +2,6 @@
 id: work-with-docker
 title: How to work with Docker?
 sidebar_label: Work with Docker
-slug: /how-to-work-with-docker
 ---
 
 [Docker](https://www.docker.com) is a service that uses OS-level virtualization

--- a/docs/import-data/cypherl.md
+++ b/docs/import-data/cypherl.md
@@ -73,7 +73,7 @@ command, but be careful of four things:
    </ul>
    <p> </p>
    <li>Remember to replace <code>HOST</code> with a valid IP of the container (see the 
-   <a href="/memgraph/how-to-work-with-docker#docker-container-ip-address"> Note for Docker users</a>).</li>
+   <a href="/how-to-guides/work-with-docker.md#docker-container-ip-address"> Note for Docker users</a>).</li>
    <p> </p>
  <li>Check that the paths of the files you want to import are correct.</li>
 </ol>
@@ -177,7 +177,7 @@ command, but be careful of four things:
    </ul>
    <p> </p>
    <li>Remember to replace <code>HOST</code> with a valid IP of the container (see the 
-   <a href="/memgraph/how-to-work-with-docker#docker-container-ip-address"> Note for Docker users</a>).</li>
+   <a href="/how-to-guides/work-with-docker.md#docker-container-ip-address"> Note for Docker users</a>).</li>
    <p> </p>
  <li>Check that the paths of the files you want to import are correct.</li>
 </ol>

--- a/docs/import-data/cypherl.md
+++ b/docs/import-data/cypherl.md
@@ -73,7 +73,7 @@ command, but be careful of four things:
    </ul>
    <p> </p>
    <li>Remember to replace <code>HOST</code> with a valid IP of the container (see the 
-   <a href="/how-to-guides/work-with-docker.md#docker-container-ip-address"> Note for Docker users</a>).</li>
+   <a href="../how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address"> Note for Docker users</a>).</li>
    <p> </p>
  <li>Check that the paths of the files you want to import are correct.</li>
 </ol>
@@ -177,7 +177,7 @@ command, but be careful of four things:
    </ul>
    <p> </p>
    <li>Remember to replace <code>HOST</code> with a valid IP of the container (see the 
-   <a href="/how-to-guides/work-with-docker.md#docker-container-ip-address"> Note for Docker users</a>).</li>
+   <a href="../how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address"> Note for Docker users</a>).</li>
    <p> </p>
  <li>Check that the paths of the files you want to import are correct.</li>
 </ol>

--- a/docs/tutorials/first-steps-with-memgraph.md
+++ b/docs/tutorials/first-steps-with-memgraph.md
@@ -265,7 +265,7 @@ We have promised along the way some more resources, so here they are:
 
 * [Cypher manual](/cypher-manual/)
 * [Guide to Style Script script](/docs/memgraph-lab/graph-style-script-language)
-* [How to work with Docker](/memgraph/how-to-work-with-docker)
+* [How to work with Docker](/how-to-guides/work-with-docker.md)
 
 We hope that you had fun going through this tutorial! You can check out
 [some of the tutorials](/memgraph/tutorials/) that we have prepared for you, or you can


### PR DESCRIPTION
### Description

I've updated the Docker how-to with a new slug and I've linked it from all of the existing docs.

We will need to update redirects once this PR is completed.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Broken links fixes
- [x] Update links

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors