### PR TITLE
[master<] Clarifying env var and mgconsole

### DIFF
--- a/docs/connect-to-memgraph/mgconsole.md
+++ b/docs/connect-to-memgraph/mgconsole.md
@@ -55,7 +55,7 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' CONT
 **3.** Now, you can start mgconsole by running the following command:
 
 ```terminal
-docker run -it --entrypoint=mgconsole memgraph --host CONTAINER_IP
+docker run -it --entrypoint=mgconsole memgraph/memgraph --host CONTAINER_IP
 ```
 
   </TabItem>

--- a/docs/connect-to-memgraph/mgconsole.md
+++ b/docs/connect-to-memgraph/mgconsole.md
@@ -18,10 +18,13 @@ If you installed **Memgraph Platform** with the Docker image
 the container. Skip the installation steps and continue with [executing
 Cypher queries](#execute-cypher-queries).
 
+If you installed any other Docker image, you need to manually run mgconsole
+following the steps described below.
+
 :::
 
-If you want to install mgconsole to query a running Memgraph database
-instance, follow the installation steps.
+If you want to install or run mgconsole to query a running Memgraph database
+instance, use the following steps:
 
 <Tabs
   groupId="platform"

--- a/docs/how-to-guides/config-logs.md
+++ b/docs/how-to-guides/config-logs.md
@@ -139,10 +139,10 @@ If you are working with the `memgraph-platform` image, you should pass
 configuration options with environmental variables.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-and set the log level to trace, pass the configuration like this:
+and set the log level to `TRACE`, pass the configuration like this:
 
 ```
-docker run -it -p 7687:7687 -p 3000:3000 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 3000:3000 -p 7444:7444 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
 ```
 
    </TabItem>
@@ -152,7 +152,7 @@ When you are working with `memgraph` or `memgraph-mage` images, you should pass
 configuration options as arguments.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-and set the log level to trace, pass the configuration argument like this:
+and set the log level to `TRACE`, pass the configuration argument like this:
 
 ```
 docker run -it -p 7687:7687  memgraph/memgraph --memory-limit=50 --log-level=TRACE

--- a/docs/how-to-guides/config-logs.md
+++ b/docs/how-to-guides/config-logs.md
@@ -135,28 +135,29 @@ passing configuration options within the `docker run` command.
   ]}>
     <TabItem value="platform">
 
-When you are working with the `memgraph-platform` image you should pass
-configuration options inside of environmental variables.
+If you are working with the `memgraph-platform` image, you should pass
+configuration options with environmental variables.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-pass the configuration like this:
+and set the log level to trace, pass the configuration like this:
 
-```plaintext
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--memory-limit=50" memgraph/memgraph-platform
+```
+docker run -it -p 7687:7687 -p 3000:3000 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
 ```
 
    </TabItem>
    <TabItem value="other">
 
-When you are working with `memgraph` or `memgraph-mage` images you should pass
-configuration options as arguments. 
+When you are working with `memgraph` or `memgraph-mage` images, you should pass
+configuration options as arguments.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-pass the configuration like this:
+and set the log level to trace, pass the configuration argument like this:
 
-```plaintext
-docker run -it -p 7687:7687 -p 7444:7444 memgraph --memory-limit=50
 ```
+docker run -it -p 7687:7687  memgraph/memgraph --memory-limit=50 --log-level=TRACE
+```
+
    
    </TabItem>
    </Tabs>

--- a/docs/how-to-guides/encryption.md
+++ b/docs/how-to-guides/encryption.md
@@ -45,7 +45,7 @@ Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&
    <code>MGCONSOLE="--use-ssl=true"</code>:
 
    ```
-   docker run -it -p 7687:7687 -p 3000:3000 -v mg_lib:/var/lib/memgraph -v mg_etc:/etc/memgraph -e MGCONSOLE="--use-ssl=true" memgraph/memgraph-platform
+   docker run -it -p 7687:7687 -p 3000:3000 -p 7444:7444 -v mg_lib:/var/lib/memgraph -v mg_etc:/etc/memgraph -e MGCONSOLE="--use-ssl=true" memgraph/memgraph-platform
    ```
 
 6. Open Memgraph Lab and switch to **Connect Manually** view, turn the **SSL

--- a/docs/how-to-guides/streams/pulsar/implement-transformation-module.md
+++ b/docs/how-to-guides/streams/pulsar/implement-transformation-module.md
@@ -33,7 +33,7 @@ docker volume create --driver local --opt type=none --opt device=modules --opt o
 Now, you can start Memgraph and mount the created volume:
 
 ```shell
-docker run -it --rm -p 7687:7687 -p 7444:7444 -p 3000:3000 -v modules:/usr/lib/memgraph/query_modules memgraph
+docker run -it --rm -p 7687:7687 -p 7444:7444 -p 3000:3000 -v modules:/usr/lib/memgraph/query_modules memgraph/memgraph
 ```
 
 Everything from the directory `/usr/lib/memgraph/query_modules` will be

--- a/docs/how-to-guides/work-with-docker.md
+++ b/docs/how-to-guides/work-with-docker.md
@@ -155,21 +155,21 @@ instead of changing the configuration file.
 If you are working with the `memgraph-platform` image, you should pass
 configuration options with environmental variables.
 
-For example, if you want to limit memory usage for the whole instance to 50 MiB,
-pass the configuration like this:
+For example, if you want to limit memory usage for the whole instance to 50 MiB
+and set the log level to trace, pass the configuration like this:
 
 ```
-docker run -it -p 7687:7687 -p 3000:3000 -e MEMGRAPH="--memory-limit=50" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 3000:3000 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
 ```
 
 When you are working with `memgraph` or `memgraph-mage` images, you should pass
 configuration options as arguments.
 
-For example, if you want to limit memory usage for the whole instance to 50 MiB,
-pass the configuration argument like this:
+For example, if you want to limit memory usage for the whole instance to 50 MiB
+and set the log level to trace, pass the configuration argument like this:
 
 ```
-docker run -it -p 7687:7687  memgraph/memgraph --memory-limit=50
+docker run -it -p 7687:7687  memgraph/memgraph --memory-limit=50 --log-level=TRACE
 ```
 
 ### Stop image

--- a/docs/how-to-guides/work-with-docker.md
+++ b/docs/how-to-guides/work-with-docker.md
@@ -105,14 +105,14 @@ image and you want to connect to both instances using the Memgraph Lab
 in-browser application. You would run the first instance with:
 
 ```
-docker run -it -p 7687:7687 -p 3000:3000 memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 memgraph/memgraph-platform
 ```
 
-Because ports `7687` and `3000` are now taken, you need to change the left side
+Because ports `7687`, `7444` and `3000` are now taken, you need to change the left side
 ports (host ports):
 
 ```
-docker run -it -p 7688:7687 -p 3001:3000 memgraph/memgraph-platform
+docker run -it -p 7688:7687 -p 7445:7444 -p 3001:3000 memgraph/memgraph-platform
 ```
 
 To connect to the first instance, you should open Memgraph Lab in your browser
@@ -156,20 +156,20 @@ If you are working with the `memgraph-platform` image, you should pass
 configuration options with environmental variables.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-and set the log level to trace, pass the configuration like this:
+and set the log level to `TRACE`, pass the configuration like this:
 
 ```
-docker run -it -p 7687:7687 -p 3000:3000 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 3000:3000 -p 7444:7444 -e MEMGRAPH="--memory-limit=50 --log-level=TRACE" memgraph/memgraph-platform
 ```
 
 When you are working with `memgraph` or `memgraph-mage` images, you should pass
 configuration options as arguments.
 
 For example, if you want to limit memory usage for the whole instance to 50 MiB
-and set the log level to trace, pass the configuration argument like this:
+and set the log level to `TRACE`, pass the configuration argument like this:
 
 ```
-docker run -it -p 7687:7687  memgraph/memgraph --memory-limit=50 --log-level=TRACE
+docker run -it -p 7687:7687 memgraph/memgraph --memory-limit=50 --log-level=TRACE
 ```
 
 ### Stop image

--- a/docs/import-data/kafka/overview.md
+++ b/docs/import-data/kafka/overview.md
@@ -78,9 +78,11 @@ command-line parameter when using Docker.
 :::caution
 
 Please remember that if you are using Memgraph Platform image, you should pass
-configuration flags within MEMGRAPH environmental variable (e.g. `docker run -e MEMGRAPH="--bolt-port=7687" memgraph/memgraph-platform`) and if you are using
-any other image, you should pass them as arguments after the image name (e.g.,
-`memgraph/memgraph-mage --bolt-port=7687 --query-modules-directory=path/path`).
+configuration flags within MEMGRAPH environmental variable (e.g. `docker run -p
+7687:7687 -p 3000:3000 -p 4777:4777 -e MEMGRAPH="--log-level=TRACE"
+memgraph/memgraph-platform`) and if you are using any other image, you should
+pass them as arguments after the image name (e.g., `... memgraph/memgraph-mage
+--log-level=TRACE --query-modules-directory=path/path`).
 
 :::
 

--- a/docs/installation/linux/docker-db-installation.md
+++ b/docs/installation/linux/docker-db-installation.md
@@ -113,8 +113,8 @@ docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
 For example, you should start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, and Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
-memgraph/memgraph-platform`.
+--bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
+MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 
 :::
 

--- a/docs/installation/linux/docker-db-installation.md
+++ b/docs/installation/linux/docker-db-installation.md
@@ -48,7 +48,7 @@ docker load -i /path-to/memgraph-<version>-docker.tar.gz
 To start Memgraph, use the following command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph
+docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph/memgraph
 ```
 
 If successful, you should see a message similar to the following:
@@ -92,7 +92,7 @@ docker run -p 7687:7687 -p 7444:7444 \
   -v mg_lib:/var/lib/memgraph \
   -v mg_log:/var/log/memgraph \
   -v mg_etc:/etc/memgraph \
-  memgraph --bolt-port=7687
+  memgraph/memgraph --log-level=TRACE
 ```
 
 The configuration file is located in the `mg_etc` volume. The exact location of
@@ -105,15 +105,16 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
+docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph --log-level=TRACE
 ```
 
 :::caution
 
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
-For example, you should start the MemgraphDB image with `docker run memgraph
---bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
+For example, you should start the MemgraphDB image with `docker run
+memgraph/memgraph --bolt-port=7687 --log-level=TRACE`, and Memgraph Platform
+with `docker run -p 7687:7687 -p 3000:3000 -p 7444:7444-e
 MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 
 :::

--- a/docs/installation/linux/docker-installation.md
+++ b/docs/installation/linux/docker-installation.md
@@ -82,7 +82,7 @@ If you need to access the Memgraph configuration file or logs, you will need to
 specify the following volumes when starting Memgraph:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" \
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" \
   -v mg_lib:/var/lib/memgraph \
   -v mg_log:/var/log/memgraph \
   -v mg_etc:/etc/memgraph \
@@ -99,7 +99,7 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" memgraph/memgraph-platform
 ```
 
 :::caution
@@ -107,9 +107,9 @@ docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7
 When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
-For example, you can start the MemgraphDB image with `docker run memgraph
+For example, you can start the MemgraphDB image with `docker run memgraph/memgraph
 --bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
-`docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
+`docker run -p 7687:7687 -p 4777:4777 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.
 
 :::

--- a/docs/installation/linux/docker-installation.md
+++ b/docs/installation/linux/docker-installation.md
@@ -108,7 +108,8 @@ When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
 For example, you can start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, but you should start Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
+--bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
+`docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.
 
 :::

--- a/docs/installation/macos/docker-db-installation.md
+++ b/docs/installation/macos/docker-db-installation.md
@@ -48,7 +48,7 @@ docker load -i /path-to/memgraph-<version>-docker.tar.gz
 To start Memgraph, use the following command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph
+docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph/memgraph
 ```
 
 If successful, you should see a message similar to the following:
@@ -92,7 +92,7 @@ docker run -p 7687:7687 -p 7444:7444 \
   -v mg_lib:/var/lib/memgraph \
   -v mg_log:/var/log/memgraph \
   -v mg_etc:/etc/memgraph \
-  memgraph --bolt-port=7687
+  memgraph/memgraph --log-level=TRACE
 ```
 
 The configuration file is located in the `mg_etc` volume. The exact location of
@@ -106,14 +106,14 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
+docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph --log-level=TRACE
 ```
 
 :::caution
 
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
-For example, you should start the MemgraphDB image with `docker run memgraph
+For example, you should start the MemgraphDB image with `docker run memgraph/memgraph
 --bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
 MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 

--- a/docs/installation/macos/docker-db-installation.md
+++ b/docs/installation/macos/docker-db-installation.md
@@ -114,8 +114,8 @@ docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
 For example, you should start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, and Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
-memgraph/memgraph-platform`.
+--bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
+MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 
 :::
 

--- a/docs/installation/macos/docker-installation.md
+++ b/docs/installation/macos/docker-installation.md
@@ -81,7 +81,7 @@ If you need to access the Memgraph configuration file or logs, you will need to
 specify the following volumes when starting Memgraph:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" \
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" \
   -v mg_lib:/var/lib/memgraph \
   -v mg_log:/var/log/memgraph \
   -v mg_etc:/etc/memgraph \
@@ -98,7 +98,7 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" memgraph/memgraph-platform
 ```
 
 :::caution
@@ -106,7 +106,7 @@ docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7
 When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
-For example, you can start the MemgraphDB image with `docker run memgraph
+For example, you can start the MemgraphDB image with `docker run memgraph/memgraph
 --bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
 `docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.

--- a/docs/installation/macos/docker-installation.md
+++ b/docs/installation/macos/docker-installation.md
@@ -107,7 +107,8 @@ When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
 For example, you can start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, but you should start Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
+--bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
+`docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.
 
 :::

--- a/docs/installation/windows/docker-db-installation.md
+++ b/docs/installation/windows/docker-db-installation.md
@@ -48,7 +48,7 @@ docker load -i /path-to/memgraph-<version>-docker.tar.gz
 To start MemgraphDB, use the following command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph
+docker run -p 7687:7687 -p 7444:7444 -v mg_lib:/var/lib/memgraph memgraph/memgraph
 ```
 
 If successful, you should see a message similar to the following:
@@ -92,7 +92,7 @@ docker run -p 7687:7687 -p 7444:7444
   -v mg_lib:/var/lib/memgraph `
   -v mg_log:/var/log/memgraph `
   -v mg_etc:/etc/memgraph `
-  memgraph --bolt-port=7687
+  memgraph/memgraph --log-level=TRACE
 ```
 
 The configuration file is located in the `mg_etc` volume. The exact location of
@@ -106,13 +106,13 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
+docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph --log-level=TRACE
 ```
 :::caution
 
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
-For example, you should start the MemgraphDB image with `docker run memgraph
+For example, you should start the MemgraphDB image with `docker run memgraph/memgraph
 --bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
 MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 

--- a/docs/installation/windows/docker-db-installation.md
+++ b/docs/installation/windows/docker-db-installation.md
@@ -113,8 +113,8 @@ docker run -p 7687:7687 -p 7444:7444 memgraph --bolt-port=7687
 When working with MemgraphDB, you should pass configuration flags as arguments.
 
 For example, you should start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, and Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
-memgraph/memgraph-platform`.
+--bolt-port=7687 --log-level=TRACE`, and Memgraph Platform with `docker run -e
+MEMGRAPH="--bolt-port=7687 --log-level=TRACE" memgraph/memgraph-platform`.
 
 :::
 

--- a/docs/installation/windows/docker-installation.md
+++ b/docs/installation/windows/docker-installation.md
@@ -109,7 +109,8 @@ When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
 For example, you can start the MemgraphDB image with `docker run memgraph
---bolt-port=7687`, but you should start Memgraph Platform with `docker run -e MEMGRAPH="--bolt-port=7687"
+--bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
+`docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.
 
 :::

--- a/docs/installation/windows/docker-installation.md
+++ b/docs/installation/windows/docker-installation.md
@@ -82,7 +82,7 @@ If you need to access the Memgraph configuration file or logs, you will need to
 specify the following volumes when starting Memgraph through **PowerShell**:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" `
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" `
   -v mg_lib:/var/lib/memgraph `
   -v mg_log:/var/log/memgraph `
   -v mg_etc:/etc/memgraph `
@@ -100,7 +100,7 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```console
-docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7687" memgraph/memgraph-platform
+docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE" memgraph/memgraph-platform
 ```
 
 :::caution
@@ -108,7 +108,7 @@ docker run -it -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--bolt-port=7
 When working with Memgraph Platform, you should pass configuration flags inside
 of environmental variables.
 
-For example, you can start the MemgraphDB image with `docker run memgraph
+For example, you can start the MemgraphDB image with `docker run memgraph/memgraph
 --bolt-port=7687 --log-level=TRACE`, but you should start Memgraph Platform with
 `docker run -e MEMGRAPH="--bolt-port=7687 --log-level=TRACE"
 memgraph/memgraph-platform`.

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -56,9 +56,12 @@ as a command-line parameter (e.g., when using Docker).
 :::caution
 
 Please remember that if you are using Memgraph Platform image, you should pass
-configuration flags within MEMGRAPH environmental variable (e.g. `docker run -e MEMGRAPH="--bolt-port=7687" memgraph/memgraph-platform`) and if you are using
-any other image you should pass them as arguments after the image name (e.g.,
-`memgraph/memgraph-mage --bolt-port=7687 --query-modules-directory=path/path`).
+configuration flags within MEMGRAPH environmental variable (e.g. `docker run -p
+7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--log-level=TRACE
+--query-modules-directory=path/path`" memgraph/memgraph-platform`) and if you
+are using any other image you should pass them as arguments after the image name
+(e.g., `... memgraph/memgraph-mage --log-level=TRACE
+--query-modules-directory=path/path`).
 
 :::
 

--- a/docs/reference-guide/users.md
+++ b/docs/reference-guide/users.md
@@ -82,13 +82,13 @@ If you are connecting with mgconsole you should add the username and password
 flags to the `docker run` command: 
 
 ```terminal
-docker run -it --entrypoint=mgconsole memgraph --host CONTAINER_IP --username=<username> --password=<password>
+docker run -it --entrypoint=mgconsole memgraph/memgraph --host CONTAINER_IP --username=<username> --password=<password>
 ```
 
 Example:
 
 ```terminal
-docker run -it --entrypoint=mgconsole memgraph --host 172.17.0.2 --username=vlasta --password=vp
+docker run -it --entrypoint=mgconsole memgraph/memgraph --host 172.17.0.2 --username=vlasta --password=vp
 ```
 
    </TabItem>

--- a/docs/templates/query-modules/_loading_query_modules.mdx
+++ b/docs/templates/query-modules/_loading_query_modules.mdx
@@ -23,14 +23,14 @@ When working with Docker and `memgraph-platform` image, you should pass
 configuration flags inside of environmental variables, for example:
 
 ```terminal
-docker run -p 7687:7686 -e MEMGRAPH="--query-modules-directory=/usr/lib/memgraph/query_modules,/usr/lib/memgraph/my_modules" memgraph/memgraph-platform`
+docker run -p 7687:7687 -p 7444:7444 -p 3000:3000 -e MEMGRAPH="--query-modules-directory=/usr/lib/memgraph/query_modules,/usr/lib/memgraph/my_modules" memgraph/memgraph-platform`
 ```
 
 If you are working with `memgraph` or `memgraph-mage` images you should pass
 configuration options like this: 
 
 ```terminal
-docker run -p 7687:7687 -p 7444:7444 memgraph --query-modules-directory=/usr/lib/memgraph/query_modules,/usr/lib/memgraph/my_modules
+docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph --query-modules-directory=/usr/lib/memgraph/query_modules,/usr/lib/memgraph/my_modules
 ```
 
 :::

--- a/errors/memgraph/durability.md
+++ b/errors/memgraph/durability.md
@@ -31,7 +31,7 @@ to store the data permanently which is why Memgraph is started with the `-v`
 flag:
 
 ```console
-docker run -p 7687:7687 -v mg_lib:/var/lib/memgraph memgraph
+docker run -p 7687:7687 -v mg_lib:/var/lib/memgraph memgraph/memgraph
 ```
 
 More information on Docker Volumes can be found

--- a/errors/memgraph/ports.md
+++ b/errors/memgraph/ports.md
@@ -46,7 +46,7 @@ When using Docker, you can also specify the configuration options in the `docker
 run` command:
 
 ```
-docker run -p 7687:7687 memgraph --bolt-port=7687
+docker run -p 7687:7687 memgraph/memgraph --log-level=TRACE
 ```
 
   </TabItem>

--- a/errors/memgraph/snapshots.md
+++ b/errors/memgraph/snapshots.md
@@ -46,7 +46,7 @@ container is stopped). You need to use local volumes to store the data
 permanently which is why Memgraph is started with the `-v` flags:
 
 ```console
-docker run -p 7687:7687 -v mg_lib:/var/lib/memgraph memgraph
+docker run -p 7687:7687 -v mg_lib:/var/lib/memgraph memgraph/memgraph
 ```
 
 More information on Docker Volumes can be found


### PR DESCRIPTION
### Description

Added another flag to clarify how multiple config flags should be passed in docker run command
Added info that mgconsole should be run manually when using memgraph and memgraph-mage images

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Documentation improvement