### PR TITLE
[release-2.4.0 < T0873] Forbid two replicas to point to the same ip port

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ sidebar_label: Changelog
 
 - Fix header on `SHOW REPLICATION ROLE` query and wrong timout info on `SHOW
   REPLICAS` query. [#376](https://github.com/memgraph/memgraph/pull/376)
+- Added a check to ensure two replicas cannot be registered to an identical end-point. [#406](https://github.com/memgraph/memgraph/pull/406)
 
 ### Major Features and Improvements
 


### PR DESCRIPTION
### Description

Added information in the changelog with regards to the registration of replicas with identical end points (bug fix).

### Pull request type
- [x] Other (please describe): Changelog

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors