### PR TITLE
[release-2.4.0 < T0882-MG]  Registering a replica with timeout 0 should not be allowed

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,7 @@ sidebar_label: Changelog
   REPLICAS` query. [#376](https://github.com/memgraph/memgraph/pull/376)
 - Added a check to ensure two replicas cannot be registered to an identical end-point. [#406](https://github.com/memgraph/memgraph/pull/406)
 - Adapted compilation flag so that the memory allocator uses JEMALLOC while counting allocated memory. [#401](https://github.com/memgraph/memgraph/pull/401)
-- Registration of a replica with `TIMEOUT 0` with command `REGISTER REPLICA` is now blocked. [#414](https://github.com/memgraph/memgraph/pull/414)
+- `REGISTER REPLICA` with `TIMEOUT 0` is no longer allowed. [#414](https://github.com/memgraph/memgraph/pull/414)
 
 ### Major Features and Improvements
 


### PR DESCRIPTION
### Description

Updated Changelog. 

### Pull request type

- [x] Other (please describe): Changelog

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors

Code [PR](https://github.com/memgraph/memgraph/pull/414)