### PR TITLE
[master < T0831-DX] Memgraph Cloud to the footer of the documentation pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -385,6 +385,10 @@ module.exports = {
           title: "More",
           items: [
             {
+              label: "Memgraph Cloud",
+              href: "https://memgraph.com/cloud"
+            },
+            {
               label: "Memgraph Playground",
               href: "https://playground.memgraph.com"
             },
@@ -393,7 +397,7 @@ module.exports = {
               href: "https://github.com/memgraph/memgraph",
             },
             {
-              label: "Youtube",
+              label: "YouTube",
               href: "https://www.youtube.com/channel/UCZ3HOJvHGxtQ_JHxOselBYg",
             },
           ],


### PR DESCRIPTION
### Description

Add a link for Memgraph Cloud to the footer of the documentation pages.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Documentation improvements

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors