### PR TITLE
[master < T0834-DX] Add two link fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@ sidebar_label: Changelog
 ### Bug Fixes
 
 - Fixed incorrect loading of C query modules.
-  [#387] (https://github.com/memgraph/memgraph/pull/387)
+  [#387](https://github.com/memgraph/memgraph/pull/387)
 
 ## v2.2.1 - Mar 17, 2022
 

--- a/docs/how-to-guides/overview.md
+++ b/docs/how-to-guides/overview.md
@@ -63,7 +63,7 @@ following guides:
 Memgraph currently provides three query modules
 that utilize the NetworkX library. Take a look how to use the NetworkX library with Memgraph:
 
-- [Utilize the NetworkX library](/how-to-guides/networkx.md))
+- [Utilize the NetworkX library](/how-to-guides/networkx.md)
 
 ## TensorFlow Op
 


### PR DESCRIPTION
### Description

I fixed one broken link in Memgraph Changelog and another in the how-to guides overview that had extra parenthesis.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Broken links fixes

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors