### PR TITLE
Changelog update

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ sidebar_label: Changelog
 - Added a check to ensure two replicas cannot be registered to an identical end-point. [#406](https://github.com/memgraph/memgraph/pull/406)
 - Adapted compilation flag so that the memory allocator uses JEMALLOC while counting allocated memory. [#401](https://github.com/memgraph/memgraph/pull/401)
 - `toString` function is now able to accept `Date`, `LocalTime`, `LocalDateTime` and `Duration` data types. [#429](https://github.com/memgraph/memgraph/pull/429)
+- `avg`, `count`, `max`, `min` aggregation functions now return `0` instead of `null` on `null` input. [#448](https://github.com/memgraph/memgraph/pull/448)
 
 ### Major Features and Improvements
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ sidebar_label: Changelog
 - Added a check to ensure two replicas cannot be registered to an identical end-point. [#406](https://github.com/memgraph/memgraph/pull/406)
 - Adapted compilation flag so that the memory allocator uses JEMALLOC while counting allocated memory. [#401](https://github.com/memgraph/memgraph/pull/401)
 - `toString` function is now able to accept `Date`, `LocalTime`, `LocalDateTime` and `Duration` data types. [#429](https://github.com/memgraph/memgraph/pull/429)
-- `avg`, `count`, `max`, `min` aggregation functions now return `0` instead of `null` on `null` input. [#448](https://github.com/memgraph/memgraph/pull/448)
+- Aggregation functions now return the openCypher-compliant results on `null` input and display the correct behavior when grouped with other operators. [#448](https://github.com/memgraph/memgraph/pull/448)
 
 ### Major Features and Improvements
 


### PR DESCRIPTION
### Description

Fixed bug where certain aggregation functions gave non-openCypher  compliant results on `null` input. Updated Changelog accordingly.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Other (please describe):
Changelog.

Closes (https://github.com/memgraph/memgraph/pull/448)

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors