### PR TITLE
[master < T0865-DX] Fix triggers reference guide link

### DIFF
--- a/docs/reference-guide/triggers.md
+++ b/docs/reference-guide/triggers.md
@@ -6,7 +6,7 @@ sidebar_label: Triggers
 
 **Database triggers** are an integral part of most database systems. A trigger is a procedural code that is automatically executed in response to specific events. Events are related to some change in data, such as created, updated and deleted data records. The trigger is often used for maintaining the integrity of the information in the database. For example, in a graph database, when a new property is added to the Employee node, a new Tax, Vacation, and Salary node should be created, along with the relationships between them. Triggers can also be used to log historical data, for example, to keep track of employees' previous salaries.
 
-[![Related -How-to](https://img.shields.io/static/v1?label=Related&message=How-to&color=blue&style=for-the-badge)](/how-to-guides/how-to-setup-triggers.md)
+[![Related -How-to](https://img.shields.io/static/v1?label=Related&message=How-to&color=blue&style=for-the-badge)](/how-to-guides/set-up-triggers.md)
 
 ## Introduction
 


### PR DESCRIPTION
### Description

The link to the triggers how-to guide from the triggers reference was broken.

### Pull request type

- [x] Broken links fixes

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors