### PR TITLE
[master<]Fix wrong path for internal_modules folder

### DIFF
--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -46,7 +46,7 @@ you are using
 
 Memgraph attempts to load the modules from all `*.so` and `*.py` files it finds
 in the default (`/usr/lib/memgraph/query_modules` and
-`/memgraph/internal_modules/`) directories. The `*.so` modules
+`/var/lib/memgraph/internal_modules/`) directories. The `*.so` modules
 are written using the C API and the `*.py` modules are written using the Python
 API. Each file corresponds to one module. Names of these files will be mapped to
 module names. For example, `hello.so` will be mapped to the `hello` module and a


### PR DESCRIPTION
### Description

Fix path to internal_modules in transformation modules overview

### Pull request type

- [x] Other (please describe): Mistake