### PR TITLE
[master < update-docosaurus-config] Return support for remark and katex

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,4 +1,6 @@
 const baseUrl = "/docs/";
+const math = require('remark-math');
+const katex = require('rehype-katex');
 
 module.exports = {
   title: "Memgraph Docs",
@@ -13,6 +15,13 @@ module.exports = {
   stylesheets: [
     "https://fonts.googleapis.com/css?family=Encode+Sans+Condensed:500,600",
     "https://fonts.googleapis.com/css?family=Roboto:400, 500,600",
+    {
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+      type: 'text/css',
+      integrity:
+        'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+      crossorigin: 'anonymous',
+    },
   ],
   scripts: [
     {
@@ -448,6 +457,8 @@ module.exports = {
         docs: {
           id: "memgraph",
           path: "docs",
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
           routeBasePath: "memgraph",
           sidebarPath: require.resolve("./sidebars/sidebarsMemgraph.js"),
           editUrl: "https://github.com/memgraph/docs/tree/master/",


### PR DESCRIPTION
### Description

Return support for remark and katex that has dropped out of the config file.

### Pull request type

- [x] Other (please describe): fix config file

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors