### PR TITLE
[master<]Fix the path to internal modules folder

### DIFF
--- a/docs/how-to-guides/streams/manage-streams.md
+++ b/docs/how-to-guides/streams/manage-streams.md
@@ -29,7 +29,7 @@ To create a transformation module, you need to:
 1. [Create a Python or a shared library file
    (module).](/reference-guide/streams/transformation-modules/overview.md#creating-a-transformation-module)
 2. Save the file into the Memgraph's `query_modules` or `internal_modules` directory (default:
-   `/usr/lib/memgraph/query_modules` and `/memgraph/internal_modules/`).
+   `/usr/lib/memgraph/query_modules` and `/var/lib/memgraph/internal_modules/`).
 3. Load the file into Memgraph either on startup (automatically) or by running a
    `CALL mg.load_all();` query.
 

--- a/docs/import-data/data-streams/manage-streams.md
+++ b/docs/import-data/data-streams/manage-streams.md
@@ -41,7 +41,7 @@ Once you [created a Python or a shared library file
 (module)](/reference-guide/streams/transformation-modules/overview.md#creating-a-transformation-module),
 save the file into the Memgraph's `query_modules` or `internal_modules`
 directory (default: `/usr/lib/memgraph/query_modules` and
-`/memgraph/internal_modules/`). If you are using Docker, you need to [transfer
+`/var/lib/memgraph/internal_modules/`). If you are using Docker, you need to [transfer
 the transformation module file into the Docker
 container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container).
 
@@ -56,7 +56,7 @@ transformation module to handle the conversion.
 
 When started, Memgraph will automatically attempt to load the transformation
 modules from all `*.so` and `*.py` files it finds in the default
-`/usr/lib/memgraph/query_modules` and `/memgraph/internal_modules` directories.
+`/usr/lib/memgraph/query_modules` and `/var/lib/memgraph/internal_modules` directories.
 
 You can point to a different directory by changing or extending the
 `--query-modules-directory` flag in the main configuration file
@@ -100,11 +100,11 @@ CALL mg.transformations() YIELD *;
 You should see an output similar to the following:
 
 ```cypher
-+------------------+------------------------------------+---------------------------------------------------------+
-| is_editable      | name                               | path                                                    |
-+------------------+------------------------------------+---------------------------------------------------------|
-| `true`           | "transformation_module.procedure"  | `/memgraph/internal_modules/transformation_module.py    |
-+------------------+------------------------------------+---------------------------------------------------------+
++------------------+------------------------------------+-----------------------------------------------------------------+
+| is_editable      | name                               | path                                                            |
++------------------+------------------------------------+-----------------------------------------------------------------|
+| `true`           | "transformation_module.procedure"  | `/var/lib/memgraph/internal_modules/transformation_module.py    |
++------------------+------------------------------------+-----------------------------------------------------------------+
 ```
 
 ## Create a stream in Memgraph

--- a/docs/reference-guide/streams/transformation-modules/api/c-api.md
+++ b/docs/reference-guide/streams/transformation-modules/api/c-api.md
@@ -298,7 +298,7 @@ clang++ --std=c++17 -Wall -shared -fPIC -I /usr/include/memgraph c_transformatio
 ```
 
 After copying the resulting `c_transformation.so` to the
-`/usr/lib/memgraph/query_modules` or `/memgraph/internal_modules` directory, we can reload the modules and check
+`/usr/lib/memgraph/query_modules` or `/var/lib/memgraph/internal_modules` directory, we can reload the modules and check
 if Memgraph found our newly created transformation:
 
 ```cypher

--- a/docs/reference-guide/streams/transformation-modules/overview.md
+++ b/docs/reference-guide/streams/transformation-modules/overview.md
@@ -17,7 +17,7 @@ To create a transformation module, you need to:
 1. Create a [Python](./api/python-api.md) or a [shared library](./api/c-api.md)
    file (module).
 2. Save the file into the Memgraph's `query_modules` or `internal_modules` directory (default:
-   `/usr/lib/memgraph/query_modules` and `/memgraph/internal_modules/`).
+   `/usr/lib/memgraph/query_modules` and `/var/lib/memgraph/internal_modules/`).
 3. Load the file into Memgraph either on startup (automatically) or by running a
    `CALL mg.load_all();` query.
 
@@ -110,7 +110,7 @@ The file is now inside your Docker container.
 
 To load a specific transformation module from a `*.so` and `*.py` files that
  were added to the default directories (`/usr/lib/memgraph/query_modules` and
-`/memgraph/internal_modules/`) while the instance was already running, use:
+`/var/lib/memgraph/internal_modules/`) while the instance was already running, use:
 
 ```
 CALL mg.load(module_name);

--- a/memgraph_versioned_docs/version-2.3.1/how-to-guides/streams/manage-streams.md
+++ b/memgraph_versioned_docs/version-2.3.1/how-to-guides/streams/manage-streams.md
@@ -29,7 +29,7 @@ To create a transformation module, you need to:
 1. [Create a Python or a shared library file
    (module).](/reference-guide/streams/transformation-modules/overview.md#creating-a-transformation-module)
 2. Save the file into the Memgraph's `query_modules` or `internal_modules` directory (default:
-   `/usr/lib/memgraph/query_modules` and `/memgraph/internal_modules/`).
+   `/usr/lib/memgraph/query_modules` and `/var/lib/memgraph/internal_modules/`).
 3. Load the file into Memgraph either on startup (automatically) or by running a
    `CALL mg.load_all();` query.
 

--- a/memgraph_versioned_docs/version-2.3.1/import-data/data-streams/manage-streams.md
+++ b/memgraph_versioned_docs/version-2.3.1/import-data/data-streams/manage-streams.md
@@ -41,7 +41,7 @@ Once you [created a Python or a shared library file
 (module)](/reference-guide/streams/transformation-modules/overview.md#creating-a-transformation-module),
 save the file into the Memgraph's `query_modules` or `internal_modules`
 directory (default: `/usr/lib/memgraph/query_modules` and
-`/memgraph/internal_modules/`). If you are using Docker, you need to [transfer
+`/var/lib/memgraph/internal_modules/`). If you are using Docker, you need to [transfer
 the transformation module file into the Docker
 container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container).
 
@@ -56,7 +56,7 @@ transformation module to handle the conversion.
 
 When started, Memgraph will automatically attempt to load the transformation
 modules from all `*.so` and `*.py` files it finds in the default
-`/usr/lib/memgraph/query_modules` and `/memgraph/internal_modules` directories.
+`/usr/lib/memgraph/query_modules` and `/var/lib/memgraph/internal_modules` directories.
 
 You can point to a different directory by changing or extending the
 `--query-modules-directory` flag in the main configuration file
@@ -100,11 +100,11 @@ CALL mg.transformations() YIELD *;
 You should see an output similar to the following:
 
 ```cypher
-+------------------+------------------------------------+---------------------------------------------------------+
-| is_editable      | name                               | path                                                    |
-+------------------+------------------------------------+---------------------------------------------------------|
-| `true`           | "transformation_module.procedure"  | `/memgraph/internal_modules/transformation_module.py    |
-+------------------+------------------------------------+---------------------------------------------------------+
++------------------+------------------------------------+-----------------------------------------------------------------+
+| is_editable      | name                               | path                                                            |
++------------------+------------------------------------+-----------------------------------------------------------------|
+| `true`           | "transformation_module.procedure"  | `/var/lib/memgraph/internal_modules/transformation_module.py    |
++------------------+------------------------------------+-----------------------------------------------------------------+
 ```
 
 ## Create a stream in Memgraph

--- a/memgraph_versioned_docs/version-2.3.1/reference-guide/streams/transformation-modules/api/c-api.md
+++ b/memgraph_versioned_docs/version-2.3.1/reference-guide/streams/transformation-modules/api/c-api.md
@@ -298,7 +298,7 @@ clang++ --std=c++17 -Wall -shared -fPIC -I /usr/include/memgraph c_transformatio
 ```
 
 After copying the resulting `c_transformation.so` to the
-`/usr/lib/memgraph/query_modules` or `/memgraph/internal_modules` directory, we can reload the modules and check
+`/usr/lib/memgraph/query_modules` or `/var/lib/memgraph/internal_modules` directory, we can reload the modules and check
 if Memgraph found our newly created transformation:
 
 ```cypher

--- a/memgraph_versioned_docs/version-2.3.1/reference-guide/streams/transformation-modules/overview.md
+++ b/memgraph_versioned_docs/version-2.3.1/reference-guide/streams/transformation-modules/overview.md
@@ -110,7 +110,7 @@ The file is now inside your Docker container.
 
 To load a specific transformation module from a `*.so` and `*.py` files that
  were added to the default directories (`/usr/lib/memgraph/query_modules` and
-`/memgraph/internal_modules/`) while the instance was already running, use:
+`/var/lib/memgraph/internal_modules/`) while the instance was already running, use:
 
 ```
 CALL mg.load(module_name);


### PR DESCRIPTION
### Description

Change the path to internal modules to /var/lib/memgraph/internal_modules

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [ ] Broken links fixes
- [ ] Language fixes
- [ ] New documentation page
- [ ] Base PR for the release
- [x] Documentation improvements
- [ ] Other (please describe):

### Checklist:

- [ ] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors