### PR TITLE
[master<] Fix broken links in encryption docs

### DIFF
--- a/docs/how-to-guides/encryption.md
+++ b/docs/how-to-guides/encryption.md
@@ -16,11 +16,11 @@ Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&
    mg_lib:/var/lib/memgraph` and `-v mg_etc:/etc/memgraph` volumes.
 
 2. [Copy the SSL certificate inside of the Docker
-   container](/memgraph/how-to-work-with-docker#how-to-copy-files-from-and-to-a-docker-container)
+   container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container)
    or use Memgraph self-signed certificates (`cert.pem` and `key.pem`) located
    at `/etc/memgraph/ssl/`.
 
-3. [Change the configuration file](/memgraph/how-to-guides/config-logs#file) to
+3. [Change the configuration file](/how-to-guides/config-logs.md#file) to
    include the following configuration flags:
 
    ```
@@ -38,7 +38,7 @@ Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&
    --bolt-key-file=/etc/memgraph/ssl/key.pem
    ```
 
-5. [Stop the Docker container](/memgraph/how-to-work-with-docker#stop-image),
+5. [Stop the Docker container](/how-to-guides/work-with-docker.md#stop-image),
    then start it again, including the volumes you used in step 1.
 
    If you are running `memgraph-platform` image, pass the configuration flag

--- a/docs/reference-guide/encryption.md
+++ b/docs/reference-guide/encryption.md
@@ -28,9 +28,9 @@ SSL certificate is a pair of `.pem` documents issued by self-signing, or by a
 Certification Authority. Memgraph contains a self-signed testing certificate
 (`cert.pem` and `key.pem`) located at `/etc/memgraph/ssl/`.
 
-If you are using Docker and want to use your own certificates, you need to [move
+If you are using Docker and want to use your own certificates, you need to [copy
 them into a Docker
-container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-Docker-container)
+container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container)
 in order to utilize them.
 
 ## Configure the server

--- a/memgraph_versioned_docs/version-2.3.1/how-to-guides/encryption.md
+++ b/memgraph_versioned_docs/version-2.3.1/how-to-guides/encryption.md
@@ -16,11 +16,11 @@ Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&
    mg_lib:/var/lib/memgraph` and `-v mg_etc:/etc/memgraph` volumes.
 
 2. [Copy the SSL certificate inside of the Docker
-   container](/memgraph/how-to-work-with-docker#how-to-copy-files-from-and-to-a-docker-container)
+   container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container)
    or use Memgraph self-signed certificates (`cert.pem` and `key.pem`) located
    at `/etc/memgraph/ssl/`.
 
-3. [Change the configuration file](/memgraph/how-to-guides/config-logs#file) to
+3. [Change the configuration file](/how-to-guides/config-logs.md#file) to
    include the following configuration flags:
 
    ```
@@ -38,7 +38,7 @@ Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&
    --bolt-key-file=/etc/memgraph/ssl/key.pem
    ```
 
-5. [Stop the Docker container](/memgraph/how-to-work-with-docker#stop-image),
+5. [Stop the Docker container](/how-to-guides/work-with-docker.md#stop-image),
    then start it again, including the volumes you used in step 1.
 
    If you are running `memgraph-platform` image, pass the configuration flag

--- a/memgraph_versioned_docs/version-2.3.1/reference-guide/encryption.md
+++ b/memgraph_versioned_docs/version-2.3.1/reference-guide/encryption.md
@@ -28,9 +28,9 @@ SSL certificate is a pair of `.pem` documents issued by self-signing, or by a
 Certification Authority. Memgraph contains a self-signed testing certificate
 (`cert.pem` and `key.pem`) located at `/etc/memgraph/ssl/`.
 
-If you are using Docker and want to use your own certificates, you need to [move
+If you are using Docker and want to use your own certificates, you need to [copy
 them into a Docker
-container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-Docker-container)
+container](/how-to-guides/work-with-docker.md#how-to-copy-files-from-and-to-a-docker-container)
 in order to utilize them.
 
 ## Configure the server


### PR DESCRIPTION
### Description

Fixed broken links in the encryption how-to and ref guide

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Broken links fixes
- [ ] Language fixes
- [ ] New documentation page
- [ ] Base PR for the release
- [ ] Documentation improvements
- [ ] Other (please describe):

### Related issues

Closes [(link to issue)](https://github.com/memgraph/docs/issues/540)

### Checklist:

- [ ] I checked all content with Grammarly
- [ ] I performed a self-review of my code
- [ ] I made corresponding changes to the rest of the documentation
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors