### PR TITLE
Update C# quick start

### DIFF
--- a/cloud/cloud-connect.md
+++ b/cloud/cloud-connect.md
@@ -269,63 +269,6 @@ public class HelloMemgraph implements AutoCloseable
 
 Read more about it on [Java Quick Start Guide](/memgraph/connect-to-memgraph/drivers/java).
 
-### C#
-
-Step 1: Install the driver with Package Manager:
-
-```
-Install-Package Neo4j.Driver.Simple
-```
-
-Step 2: Copy the following code and fill out the missing details (`YOUR_MEMGRAPH_PASSWORD`, `YOUR_MEMGRAPH_USERNAME` and `MEMGRAPH_HOST_ADDRESS`) before running it:
-
-```cs
-using System;
-using System.Linq;
-using Neo4j.Driver;
-
-namespace MemgraphApp
-{
-    public class Program : IDisposable
-    {
-        private readonly IDriver _driver;
-
-        public Program(string uri, string user, string password)
-        {
-            _driver = GraphDatabase.Driver(uri, AuthTokens.Basic(user, password));
-        }
-
-        public void CreateAndPrintNode(string message)
-        {
-            using (var session = _driver.Session())
-            {
-                var nodeMessage = session.WriteTransaction(tx =>
-                {
-                    var result = tx.Run("CREATE (n:FirstNode {message: $message}) " +
-                                        "RETURN id(n) AS nodeId, n.message AS message",
-                        new { message });
-                    return result.Single()[1].As<string>();
-                });
-                Console.WriteLine("Created node:", nodeMessage);
-            }
-        }
-
-        public void Dispose()
-        {
-            _driver?.Dispose();
-        }
-
-        public static void Main()
-        {
-            using (var program = new Program("bolt+ssc://MEMGRAPH_HOST_ADDRESS:7687", "YOUR_MEMGRAPH_USERNAME", "<YOUR_MEMGRAPH_PASSWORD>"))
-            {
-                program.CreateAndPrintNode("Hello Memgraph from C#!");
-            }
-        }
-    }
-}
-```
-
 ### Golang
 
 Step 1: Make sure your application has been set up to use go modules (there should be a `go.mod` file in your application root). Add the driver with:

--- a/docs/connect-to-memgraph/drivers/c-sharp.md
+++ b/docs/connect-to-memgraph/drivers/c-sharp.md
@@ -13,7 +13,14 @@ queries.
 For this guide you will need:
 
 - A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
 - A basic understanding of graph databases and the property graph model.
 
 ## Driver
@@ -27,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -37,19 +44,15 @@ Let's jump in and connect a simple program to Memgraph.
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
 **3.** Name your project **_MemgraphApp_**, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j.Driver.Simple**.
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -63,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -89,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -108,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +

--- a/memgraph_versioned_docs/version-2.3.0/connect-to-memgraph/drivers/c-sharp.md
+++ b/memgraph_versioned_docs/version-2.3.0/connect-to-memgraph/drivers/c-sharp.md
@@ -11,9 +11,17 @@ queries.
 ## Prerequisites
 
 For this guide you will need:
-* A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
-* A basic understanding of graph databases and the property graph model.
+
+- A **running Memgraph instance**. If you need to set up Memgraph, take a look
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
+- A basic understanding of graph databases and the property graph model.
 
 ## Driver
 
@@ -26,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -35,20 +43,16 @@ Let's jump in and connect a simple program to Memgraph.
 
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
-**3.** Name your project ***MemgraphApp***, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j. Driver. Simple**.
+**3.** Name your project **_MemgraphApp_**, choose an appropriate location for
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -62,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -88,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -107,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +
@@ -139,5 +141,5 @@ namespace MemgraphApp
 
 For real-world examples of how to use Memgraph, we suggest you take a look at
 the **[Tutorials](/tutorials/overview.md)** page. You can also browse through
-the **[How-to guides](/how-to-guides/overview.md)**
-section to get an overview of all the functionalities Memgraph offers.
+the **[How-to guides](/how-to-guides/overview.md)** section to get an overview
+of all the functionalities Memgraph offers.

--- a/memgraph_versioned_docs/version-2.3.1/connect-to-memgraph/drivers/c-sharp.md
+++ b/memgraph_versioned_docs/version-2.3.1/connect-to-memgraph/drivers/c-sharp.md
@@ -13,7 +13,14 @@ queries.
 For this guide you will need:
 
 - A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
 - A basic understanding of graph databases and the property graph model.
 
 ## Driver
@@ -27,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -37,19 +44,15 @@ Let's jump in and connect a simple program to Memgraph.
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
 **3.** Name your project **_MemgraphApp_**, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j.Driver.Simple**.
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -63,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -89,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -108,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +

--- a/memgraph_versioned_docs/version-2.4.0/connect-to-memgraph/drivers/c-sharp.md
+++ b/memgraph_versioned_docs/version-2.4.0/connect-to-memgraph/drivers/c-sharp.md
@@ -13,7 +13,14 @@ queries.
 For this guide you will need:
 
 - A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
 - A basic understanding of graph databases and the property graph model.
 
 ## Driver
@@ -27,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -37,19 +44,15 @@ Let's jump in and connect a simple program to Memgraph.
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
 **3.** Name your project **_MemgraphApp_**, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j.Driver.Simple**.
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -63,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -89,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -108,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +

--- a/memgraph_versioned_docs/version-2.4.1/connect-to-memgraph/drivers/c-sharp.md
+++ b/memgraph_versioned_docs/version-2.4.1/connect-to-memgraph/drivers/c-sharp.md
@@ -13,7 +13,14 @@ queries.
 For this guide you will need:
 
 - A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
 - A basic understanding of graph databases and the property graph model.
 
 ## Driver
@@ -27,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -37,19 +44,15 @@ Let's jump in and connect a simple program to Memgraph.
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
 **3.** Name your project **_MemgraphApp_**, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j.Driver.Simple**.
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -63,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -89,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -108,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +

--- a/memgraph_versioned_docs/version-2.4.2/connect-to-memgraph/drivers/c-sharp.md
+++ b/memgraph_versioned_docs/version-2.4.2/connect-to-memgraph/drivers/c-sharp.md
@@ -13,7 +13,14 @@ queries.
 For this guide you will need:
 
 - A **running Memgraph instance**. If you need to set up Memgraph, take a look
-  at the [Installation guide](/installation/overview.mdx).
+  at the [Installation guide](/installation/overview.mdx). 
+  :::caution
+    In order for the Neo4j driver to work, you need [modify configuration
+    setting](/docs/memgraph/how-to-guides/config-logs)
+    `--bolt-server-name-for-init`. When running Memgraph, set
+    `--bolt-server-name-for-init=Neo4j/5.2.0`. If you use other version of Neo4j
+    driver, make sure to put the appropriate version number.
+  :::
 - A basic understanding of graph databases and the property graph model.
 
 ## Driver
@@ -27,7 +34,7 @@ Driver](https://github.com/neo4j/neo4j-dotnet-driver).
 
 ## Basic Setup
 
-We'll be using Visual Studio 2019 on Windows 10 to connect a simple . NET
+We'll be using Visual Studio 2022 on Windows 10 to connect a simple . NET
 console application to a running Memgraph instance. If you're using a different
 IDE, the steps might be slightly different, but the code is either the same or
 very similar.<br />
@@ -37,19 +44,15 @@ Let's jump in and connect a simple program to Memgraph.
 **1.** Open **Visual Studio** and create a new project.<br /> **2.** Find and
 select the **Console App (. NET Core)** template by using the search box.<br />
 **3.** Name your project **_MemgraphApp_**, choose an appropriate location for
-it, and click **Create**.<br /> **4.** Select the **Tools > NuGet Package
-Manager > Package Manager Console** menu command.<br /> **5.** Once the console
-opens, check that the **Default project** drop-down list shows the project into
-which you want to install the package. If you have a single project in the
-solution, it is already selected.<br /> **6.** Enter the command
-**Install-Package Neo4j.Driver.Simple**.
+it, and click **Create**.<br /> **4.** Select the **Tools > Manage NuGet
+Packages** menu command.<br /> **5.** Once the window opens, search for the
+**Neo4j.Driver.Simple**.<br /> **6.** Select the appropriate driver and click **Add
+package**.
 
 Now, you should have the newest version of the driver installed and can proceed
 to copy the following code into the **Program.cs** file.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -63,7 +66,7 @@ namespace MemgraphApp
             using var _driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.None);
             using var session = _driver.Session();
 
-            var greeting = session.WriteTransaction(tx =>
+            var greeting = session.ExecuteWrite(tx =>
             {
                 var result = tx.Run("CREATE (n:FirstNode) " +
                                     "SET n.message = $message " +
@@ -89,8 +92,6 @@ If you want to try out more complex operations, feel free to use the refactored
 code below.
 
 ```csharp
-using System;
-using System.Linq;
 using Neo4j.Driver;
 
 namespace MemgraphApp
@@ -108,7 +109,7 @@ namespace MemgraphApp
         {
             using (var session = _driver.Session())
             {
-                var greeting = session.WriteTransaction(tx =>
+                var greeting = session.ExecuteWrite(tx =>
                 {
                     var result = tx.Run("CREATE (n:FirstNode) " +
                                         "SET n.message = $message " +


### PR DESCRIPTION
### Description

I updated C# quick start guide in the next and current versions. I deleted Cloud docs for the C# driver because it's still not possible to connect to a Cloud instance with the C# driver (`--bolt-server-name-for-init` needs to be reconfigured).

### Pull request type

- [x] Documentation improvements

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors