### PR TITLE
[master < T553-FL] Extend backup & restore docs to address user questions 

### DIFF
--- a/docs/how-to-guides/create-backup.md
+++ b/docs/how-to-guides/create-backup.md
@@ -4,20 +4,20 @@ title: How to create a backup
 sidebar_label: Create a backup
 ---
 
-While running, Memgraph generates various files in the **data directory**,
-including the durability files - snapshots and WAL files that contain Memgraph's
-data in a recoverable format. The default data directory is `/var/lib/memgraph`,
-but you can change it in the main [Memgraph configuration
-file](/docs/memgraph/reference-guide/configuration).
+While running, Memgraph generates various files in its
+[data directory](/docs/memgraph/reference-guide/backup),
+including the **durability files**: snapshots and WALs that contain Memgraph's
+data in a recoverable format. On startup, it searches for previously saved
+durability files and uses them to recreate the most recent DB state.
 
 Snapshots are created periodically based on the value defined with the
 `--storage-snapshot-interval-sec` configuration flag in the configuration file.
-If you need help adjusting the configuration, check out [the how-to guide on
+If you need help adjusting the configuration, check out the [how-to guide on
 changing the configuration](/docs/memgraph/how-to-guides/config-logs).
 
 [![Related - Reference Guide](https://img.shields.io/static/v1?label=Related&message=Reference%20Guide&color=yellow&style=for-the-badge)](/reference-guide/backup.md)
 
-To create a backup follow the steps below.
+To create a backup, follow the steps below:
 
 ## 1. Create a snapshot
 

--- a/docs/reference-guide/backup.md
+++ b/docs/reference-guide/backup.md
@@ -74,6 +74,13 @@ You can easily back up Memgraph by following a three-step process:
 2. Lock the data directory
 3. Copy the snapshot to the backup location and unlock the directory
 
+The following queries lock/unlock the data directory:
+
+```opencypher
+UNLOCK DATA DIRECTORY;
+LOCK DATA DIRECTORY;
+```
+
 A detailed guide is available
 [here](/docs/memgraph/how-to-guides/create-backup).
 


### PR DESCRIPTION
### Description

* Mention recovery in [How to create a backup](https://memgraph.com/docs/memgraph/how-to-guides/create-backup)
* extend [Data durability](https://memgraph.com/docs/memgraph/reference-guide/backup) with disaster recovery, `DUMP DATABASE` and configuration

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Documentation improvements

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors