### PR TITLE
[master<231402] Replication docs fix

### DIFF
--- a/docs/how-to-guides/replication.md
+++ b/docs/how-to-guides/replication.md
@@ -91,7 +91,7 @@ The IP addresses will probably be:
 - REPLICA instance 2 - `172.17.0.4`
 
 If they are not, please change the IP addresses in the following queries to
-match the IP addresses on your cluster.
+match the [IP addresses on your cluster](/memgraph/how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address).
 
 Then, run the following queries from the MAIN instance to register REPLICA
 instances:
@@ -105,11 +105,8 @@ instances:
    REPLICA instance 1 is called REP1, its replication mode is SYNC, and it is
    located at IP address `172.17.0.3.` with port `10000`.
 
-   Once the MAIN instance commits a transaction, it will
-   communicate the changes to all REPLICA instances running 
-   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached. <br/>
-   In the case of a timeout, the MAIN instance will return an error to the user proposing a check of the 
-   REPLICAs' statuses as there might be network or hardware issues.
+   Once the MAIN instance commits a transaction, it will communicate the changes
+   to all REPLICA instances running in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached.
 
    If you used any port other than `10000` while demoting a REPLICA instance,
    you will need to specify it like this: "172.17.0.3:5000"

--- a/docs/reference-guide/replication.md
+++ b/docs/reference-guide/replication.md
@@ -50,9 +50,7 @@ changes to the database, thus modifying the system to prioritize either
 consistency or availability:
 
 - **SYNC** - After committing a transaction, the MAIN instance will communicate the changes 
-to all REPLICA instances running in SYNC mode and wait until it receives a response or that 
-a timeout is reached. <br/>
-In the case of a timeout, it will return an error to the user indicating that they should check the MAIN instance will return an error to the user proposing a check of  REPLICAs' statuses as there might be network or hardware issues.
+to all REPLICA instances running in SYNC mode and wait until it receives a response or that a timeout is reached.
 
 - **ASYNC** - The MAIN instance will commit a transaction without receiving
   confirmation from REPLICA instances that they have received the same
@@ -129,8 +127,8 @@ retrieve its original function. You need to drop it from the MAIN and register
 it again.
 
 If the crashed MAIN instance goes back online, it cannot reclaim its previous
-role. It has to be demoted and become a REPLICA instance of the new MAIN
-instance.
+role. It needs to be cleaned and demoted to become a REPLICA instance of the new MAIN
+instance. 
 
 ### Checking the assigned role
 

--- a/docs/under-the-hood/replication.md
+++ b/docs/under-the-hood/replication.md
@@ -59,7 +59,7 @@ WAL files is impossible, Memgraph will use snapshots.
 :::info
 
 From version 2.4 it is no longer possible to specify a timeout when registering
-a sync replica. To mimic this behavior in higher releases, please use ASYNC
+a SYNC replica. To mimic this behavior in higher releases, please use ASYNC
 replication instead.
 
 :::
@@ -84,10 +84,7 @@ registration.
 
 SYNC mode is the most straightforward replication mode in which the main storage
 thread waits for the response and cannot continue until the response is
-received or a timeout is reached. If the timeout is reached and at least one SYNC REPLICA has not
-sent back a response, then the MAIN instance will return an error to the user.<br/>
-The error indicates that the user should check the status of the REPLICAs
-as there might be a network or hardware issue.
+received or a timeout is reached.
 
 The following diagrams express the behavior of the MAIN instance in cases when
 SYNC REPLICA doesn't answer within the expected timeout.

--- a/memgraph_versioned_docs/version-2.5.0/how-to-guides/replication.md
+++ b/memgraph_versioned_docs/version-2.5.0/how-to-guides/replication.md
@@ -91,7 +91,7 @@ The IP addresses will probably be:
 - REPLICA instance 2 - `172.17.0.4`
 
 If they are not, please change the IP addresses in the following queries to
-match the IP addresses on your cluster.
+match the [IP addresses on your cluster](/memgraph/how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address).
 
 Then, run the following queries from the MAIN instance to register REPLICA
 instances:
@@ -107,9 +107,7 @@ instances:
 
    Once the MAIN instance commits a transaction, it will
    communicate the changes to all REPLICA instances running 
-   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached. <br/>
-   In the case of a timeout, the MAIN instance will return an error to the user proposing a check of the 
-   REPLICAs' statuses as there might be network or hardware issues.
+   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached.
 
    If you used any port other than `10000` while demoting a REPLICA instance,
    you will need to specify it like this: "172.17.0.3:5000"

--- a/memgraph_versioned_docs/version-2.5.0/reference-guide/replication.md
+++ b/memgraph_versioned_docs/version-2.5.0/reference-guide/replication.md
@@ -51,8 +51,7 @@ consistency or availability:
 
 - **SYNC** - After committing a transaction, the MAIN instance will communicate the changes 
 to all REPLICA instances running in SYNC mode and wait until it receives a response or that 
-a timeout is reached. <br/>
-In the case of a timeout, it will return an error to the user indicating that they should check the MAIN instance will return an error to the user proposing a check of  REPLICAs' statuses as there might be network or hardware issues.
+a timeout is reached.
 
 - **ASYNC** - The MAIN instance will commit a transaction without receiving
   confirmation from REPLICA instances that they have received the same

--- a/memgraph_versioned_docs/version-2.5.1/how-to-guides/replication.md
+++ b/memgraph_versioned_docs/version-2.5.1/how-to-guides/replication.md
@@ -91,7 +91,7 @@ The IP addresses will probably be:
 - REPLICA instance 2 - `172.17.0.4`
 
 If they are not, please change the IP addresses in the following queries to
-match the IP addresses on your cluster.
+match the [IP addresses on your cluster](/memgraph/how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address).
 
 Then, run the following queries from the MAIN instance to register REPLICA
 instances:
@@ -107,9 +107,7 @@ instances:
 
    Once the MAIN instance commits a transaction, it will
    communicate the changes to all REPLICA instances running 
-   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached. <br/>
-   In the case of a timeout, the MAIN instance will return an error to the user proposing a check of the 
-   REPLICAs' statuses as there might be network or hardware issues.
+   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached.
 
    If you used any port other than `10000` while demoting a REPLICA instance,
    you will need to specify it like this: "172.17.0.3:5000"

--- a/memgraph_versioned_docs/version-2.5.1/reference-guide/replication.md
+++ b/memgraph_versioned_docs/version-2.5.1/reference-guide/replication.md
@@ -51,8 +51,7 @@ consistency or availability:
 
 - **SYNC** - After committing a transaction, the MAIN instance will communicate the changes 
 to all REPLICA instances running in SYNC mode and wait until it receives a response or that 
-a timeout is reached. <br/>
-In the case of a timeout, it will return an error to the user indicating that they should check the MAIN instance will return an error to the user proposing a check of  REPLICAs' statuses as there might be network or hardware issues.
+a timeout is reached.
 
 - **ASYNC** - The MAIN instance will commit a transaction without receiving
   confirmation from REPLICA instances that they have received the same

--- a/memgraph_versioned_docs/version-2.5.2/how-to-guides/replication.md
+++ b/memgraph_versioned_docs/version-2.5.2/how-to-guides/replication.md
@@ -91,7 +91,7 @@ The IP addresses will probably be:
 - REPLICA instance 2 - `172.17.0.4`
 
 If they are not, please change the IP addresses in the following queries to
-match the IP addresses on your cluster.
+match the [IP addresses on your cluster](/memgraph/how-to-guides/work-with-docker#how-to-retrieve-a-docker-container-ip-address).
 
 Then, run the following queries from the MAIN instance to register REPLICA
 instances:
@@ -107,9 +107,7 @@ instances:
 
    Once the MAIN instance commits a transaction, it will
    communicate the changes to all REPLICA instances running 
-   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached. <br/>
-   In the case of a timeout, the MAIN instance will return an error to the user proposing a check of the 
-   REPLICAs' statuses as there might be network or hardware issues.
+   in SYNC mode and wait until it receives a response that the changes have been applied to the REPLICAs or that a timeout has been reached.
 
    If you used any port other than `10000` while demoting a REPLICA instance,
    you will need to specify it like this: "172.17.0.3:5000"

--- a/memgraph_versioned_docs/version-2.5.2/reference-guide/replication.md
+++ b/memgraph_versioned_docs/version-2.5.2/reference-guide/replication.md
@@ -51,8 +51,7 @@ consistency or availability:
 
 - **SYNC** - After committing a transaction, the MAIN instance will communicate the changes 
 to all REPLICA instances running in SYNC mode and wait until it receives a response or that 
-a timeout is reached. <br/>
-In the case of a timeout, it will return an error to the user indicating that they should check the MAIN instance will return an error to the user proposing a check of  REPLICAs' statuses as there might be network or hardware issues.
+a timeout is reached.
 
 - **ASYNC** - The MAIN instance will commit a transaction without receiving
   confirmation from REPLICA instances that they have received the same


### PR DESCRIPTION
### Description

Added a link to finding instance IP address in Docker
Removed that the MAIN will receive an error if a SYNC instance is unavaliable

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] Documentation fix
- [ ] New documentation page 
- [ ] Base PR for the release
- [ ] Documentation improvements
- [ ] Other (please describe):

### Related PRs and issues

PR this doc page is related to: 
Closes https://github.com/memgraph/docs/issues/708
