### PR TITLE
Add docs for where exists

### DIFF
--- a/cypher-manual/clauses/where.md
+++ b/cypher-manual/clauses/where.md
@@ -21,6 +21,7 @@ order to avoid problems with performance or results.
    1.4. [Filter with node properties](#14-filter-with-node-properties)<br />
    1.5. [Filter with relationship properties](#15-filter-with-relationship-properties)<br />
    1.6. [Check if property is not null](#16-check-if-property-is-not-null)<br />
+   1.7. [Filter with pattern expressions](#17-filter-with-pattern-expressions)<br />
 2. [String matching](#2-string-matching)<br />
 3. [Regular Expressions](#3-regular-expressions)
 
@@ -159,6 +160,29 @@ Output:
 +----------------+----------------+
 | United Kingdom | 66000000       |
 +----------------+----------------+
+```
+
+### 1.7. Filter with pattern expressions
+
+Currently, we support pattern expression filters with the `exists(pattern)` function, which can perform filters based on
+neighboring entities:
+
+```cypher
+MATCH (p:Person)
+WHERE exists((p)-[:LIVING_IN]->(:Country {name: 'Germany'}))
+RETURN p.name
+ORDER BY p.name;
+```
+
+Output:
+
+```nocopy
++----------------+
+| c.name         |
++----------------+
+| Anna           |
+| John           |
++----------------+
 ```
 
 ## 2. String matching

--- a/cypher-manual/differences-in-cypher-implementations.md
+++ b/cypher-manual/differences-in-cypher-implementations.md
@@ -56,37 +56,7 @@ List functions:
 
 ## Patterns in expressions
 
-Patterns in expressions are not yet supported in Memgraph. For example, Memgraph
-doesn't support `size((n)-->())`. Most of the time, the same functionalities can
-be expressed differently in Memgraph using `OPTIONAL` expansions, function
-calls, etc.
-
-### What is a Cypher alternative for patterns in expressions?
-
-For example, the following query is not valid in Memgraph:
-
-```cypher
-MATCH (n:NodeA)
-WHERE NOT (n)-[]->(:NodeB)
-RETURN n;
-```
-
-After executing it, you would receive an error:
-
-```plaintext
-Not yet implemented: atom expression '(n)-[]->(:NodeB)'
-```
-
-The same query can be expressed using the `OPTIONAL MATCH` clause.<br/>
-The clause `OPTIONAL MATCH` behaves the same as a regular MATCH, but when it
-fails to find the pattern, missing parts of the pattern will be filled with
-`null` values.
-
-The example query would look like this:
-
-```cypher
-OPTIONAL MATCH (n:NodeA)-[]->(m:NodeB)
-WHERE m IS null
-RETURN DISTINCT n;
-```
-
+Patterns in expressions are supported in Memgraph in particular functions, like `exists(pattern)`.
+In other cases, Memgraph does not yet support patterns in functions, e.g. `size((n)-->())`.
+Most of the time, the same functionalities can be expressed differently in Memgraph
+using `OPTIONAL` expansions, function calls, etc.

--- a/cypher-manual/functions.md
+++ b/cypher-manual/functions.md
@@ -45,6 +45,10 @@ This section contains the list of supported functions.
  | `type`       | `type(relationship: Relationship) -> (string)`                                       | Returns the type of a relationships as a character string.                                                                                                                                                                                       |
  | `timestamp`  | `timestamp() -> (integer)`                                                           | Returns the difference, measured in microseconds, between the current time and midnight, January 1, 1970 UTC.                                                                                                                            |
 
+### Pattern functions
+ | Name            | Signature                                                                                      | Description                                                                                                                                |
+ | --------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+ | `exists`           | `exists(pattern: Pattern)`                                                        | Checks if a pattern exists as part of the filtering clause. Symbols provided in the MATCH clause can also be used here. |
 
  ### Lists
 


### PR DESCRIPTION
### Description

Where exists is the first feature with pattern expressions in filters. Users don't need to do optional match but directly use WHERE exists after match clauses

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [X] Documentation improvements

### Checklist:

- [ ] I checked all content with Grammarly
- [X] I performed a self-review of my code
- [X] I made corresponding changes to the rest of the documentation
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
