### PR TITLE
Python mock API documentation

### DIFF
--- a/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
@@ -1,0 +1,93 @@
+---
+id: mock-python-api
+title: Mock Python query module API
+sidebar_label: Mock Python API
+slug: /reference-guide/query-modules/api/mock-python-api
+---
+
+The mock Python query module API enables you to develop and test query modules
+for Memgraph without having to run a Memgraph instance by simulating its
+behavior. As the mock API is compatible with the
+[Python API](/reference-guide/query-modules/implement-custom-query-modules/api/python-api.md),
+you can add modules developed with it to Memgraph as-is, without modifying the
+code.
+
+It is implemented in `mgp_mock.py`, which contains definitions of all
+classes and functions provided for developing query module procedures and
+functions. The source file is found in the Memgraph installation directory,
+under `/usr/include/memgraph`.
+
+## API reference
+
+Because the mock API’s classes and functions are compatible with the corresponding
+Python API classes and functions, the
+[Python API reference](/reference-guide/query-modules/implement-custom-query-modules/api/python-api.md)
+applies, with the following exceptions:
+
+* Query procedure returns (`Record` class) are printable.
+* The mock API doesn’t throw errors having to do with Memgraph-internal
+  behavior (`UnableToAllocateError`, `InsufficientBufferError`,
+  `OutOfRangeError`, `KeyAlreadyExistsError`, `SerializationError` and
+  `AuthorizationError`).
+* The mock API doesn’t contain two Python API methods dealing with
+  Memgraph-internal behavior (`must_abort` and `check_must_abort`).
+  These methods are used to check whether Memgraph has notified the query
+  module to abort its execution.
+* The constructors of the `ProcCtx` and `FuncCtx` classes take a NetworkX
+  [MultiDiGraph](https://networkx.org/documentation/stable/reference/classes/multidigraph.html)
+  because that’s the data structure the mock API uses for internal graph
+  representations.
+* Transformation modules are currently not implemented.
+
+### Graph representation
+
+The mock Python API uses a graph representation based on the NetworkX
+[MultiDiGraph](https://networkx.org/documentation/stable/reference/classes/multidigraph.html),
+which is a directed graph that supports parallel edges (relationships) and
+custom node/relationship attributes.
+
+All elements of a Memgraph graph are supported by the mock API, with the
+following rules about representing node labels and relationship types:
+
+* Node labels are stored in the node attribute named `"labels"` as a
+  `":"`-separated string, e.g. the node `(n:Actor:Director)` has
+  `{"labels": "Actor:Director"}`.
+* Edge types are strings stored in `"type"`.
+
+## Using the mock API
+
+### Importing
+
+Before importing the mock API, you need to make it visible to the query module,
+e.g. by adding the path of `mgp_mock.py` to PYTHONPATH or copying `mgp_mock.py`
+to the directory containing the module.
+
+### Running
+
+The following code block contains an example query procedure and a runner for
+query procedures:
+
+```python
+import mgp_mock as mgp
+import networkx as nx
+
+@mgp.read_proc
+def example_procedure(context: mgp.ProcCtx) -> mgp.Record(status=str):
+    return mgp.Record(status="Hello, world!")
+
+graph = nx.MultiDiGraph() # Empty graph
+context = mgp.ProcCtx(graph) # Create a context instance
+
+result = example_procedure(context) # Run the procedure
+print(result) # Hello, world!
+```
+
+### Running the module with Memgraph
+
+As the mock Python API is compatible with the Python query module API, adding a
+module developed with the mock API to Memgraph is a simple task.
+
+1. Replace the `mgp_mock` import with `import mgp`
+   * This includes refactoring the usages of `mgp_mock` (or alias) to `mgp`.
+2. Load the query module normally
+   ([reference](https://memgraph.com/docs/mage/usage/loading-modules))

--- a/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
@@ -89,5 +89,4 @@ module developed with the mock API to Memgraph is a simple task.
 
 1. Replace the `mgp_mock` import with `import mgp`
    * This includes refactoring the usages of `mgp_mock` (or alias) to `mgp`.
-2. Load the query module normally
-   ([reference](https://memgraph.com/docs/mage/usage/loading-modules))
+2. [Load the query module.](/reference-guide/query-modules/load-call-query-modules.md)

--- a/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md
@@ -14,8 +14,8 @@ code.
 
 It is implemented in `mgp_mock.py`, which contains definitions of all
 classes and functions provided for developing query module procedures and
-functions. The source file is found in the Memgraph installation directory,
-under `/usr/include/memgraph`.
+functions. The source file is located in the Memgraph installation directory,
+inside `/usr/include/memgraph`.
 
 ## API reference
 

--- a/docs/reference-guide/query-modules/implement-custom-query-modules/overview.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/overview.md
@@ -28,6 +28,18 @@ navigate to **Query Modules** and click on **New Module** to start.
 Custom modules developed via Memgraph Lab are located at
 `/var/lib/memgraph/internal_modules`.
 
+### Mock API
+
+The [mock Python query module API](api/mock-python-api.md) enables you to
+develop and test query modules for Memgraph without having to run a Memgraph
+instance by simulating its behavior. As the mock API is compatible with the
+[Python API](/reference-guide/query-modules/implement-custom-query-modules/api/python-api.md),
+you can add modules developed with it to Memgraph as-is, without modifying the
+code.
+
+For more information and examples, check the
+[mock Python API reference guide](api/mock-python-api.md).
+
 ## C API
 
 C API modules need to be compiled to a shared library so that they can be loaded

--- a/docs/reference-guide/query-modules/implement-custom-query-modules/overview.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/overview.md
@@ -28,7 +28,7 @@ navigate to **Query Modules** and click on **New Module** to start.
 Custom modules developed via Memgraph Lab are located at
 `/var/lib/memgraph/internal_modules`.
 
-### Mock API
+### Mock Python API
 
 The [mock Python query module API](api/mock-python-api.md) enables you to
 develop and test query modules for Memgraph without having to run a Memgraph

--- a/docs/reference-guide/query-modules/overview.md
+++ b/docs/reference-guide/query-modules/overview.md
@@ -55,6 +55,7 @@ To learn more about query modules, take a look at the following guides:
   using:
   - **[Python
     API](/reference-guide/query-modules/implement-custom-query-modules/api/python-api.md)**
+    - [**Mock Python API**](/reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api.md)
   - **[C
     API](/reference-guide/query-modules/implement-custom-query-modules/api/c-api.md)**
   - **[C++

--- a/mage/how-to-guides/create-a-new-module-python.md
+++ b/mage/how-to-guides/create-a-new-module-python.md
@@ -4,54 +4,51 @@ title: How to create a query module in Python
 sidebar_label: Create a Python query module
 ---
 
-Query modules can be implemented using the [Python
-API](/memgraph/reference-guide/query-modules/api/python-api) provided by
-Memgraph. In this tutorial, we will learn how to develop a query module in
+The [Python API](/memgraph/reference-guide/query-modules/api/python-api)
+provided by Memgraph lets you develop query modules. It is accompanied by the
+[mock API](https://memgraph.com/docs/memgraph/reference-guide/query-modules/api/mock-python-api), which
+makes it possible to develop and test query modules for Memgraph without having
+to run a Memgraph instance.
+
+In this tutorial, we will learn how to develop a query module in
 Python on the example of the **random walk algorithm**.
 
 ## Prerequisites
 
 There are three options for installing and working with Memgraph MAGE:
 
-1.  **Pulling the `memgraph/memgraph-mage` image**: check the `Docker Hub` 
-    [installation guide](/installation/docker-hub.md).
-2.  **Building a Docker image from the MAGE repository**: check the `Docker
-    build` [installation guide](/installation/docker-build.md).
-3.  **Building MAGE from source**: check the `Build from source on Linux` 
-    [installation guide](/installation/source.md).
+1. **Pulling the `memgraph/memgraph-mage` image**: check the `Docker Hub`
+   [installation guide](/installation/docker-hub.md).
+2. **Building a Docker image from the MAGE repository**: check the `Docker
+   build` [installation guide](/installation/docker-build.md).
+3. **Building MAGE from source**: check the `Build from source on Linux`
+   [installation guide](/installation/source.md).
 
 ## Developing a module
 
 :::note
 
-These steps are the same for every type of MAGE installation: _Docker Hub_,
-_Docker build_ and _Build from source on Linux_.
+These steps are the same for all MAGE installation options (_Docker Hub_,
+_Docker build_ and _Build from source on Linux_).
 
 :::
 
 Position yourself in the **MAGE repository** you cloned earlier. Specifically,
-go in the `python` subdirectory and create a new file called `random_walk.py`.
+go in the `python` subdirectory and create a new file named `random_walk.py`.
 
 ```plaintext
-python
-└── mage
-    random_walk.py
+mage
+└── python
+    └── random_walk.py
 
 ```
 
-For this part, we will import [`mgp`](https://github.com/memgraph/mgp),
-Memgraph's internal data structure module. Among others, it contains definitions
-for [**Vertex**](https://github.com/memgraph/mgp/blob/main/mgp.py#L260) and
-[**Edge** ](https://github.com/memgraph/mgp/blob/main/mgp.py#L182)data
-structures.
-
-:::tip
-
-Install the `mgp` Python module so your editor can use typing annotations
-properly and suggest methods and classes it contains. You can install the module
-by running `pip install mgp`.
-
-:::
+For coding the query module, we’ll use the
+[`mgp`](https://github.com/memgraph/mgp) package that has the Memgraph Python
+API including the key graph data structures:
+[**Vertex**](https://github.com/memgraph/mgp/blob/main/mgp.py#L260) and
+[**Edge**](https://github.com/memgraph/mgp/blob/main/mgp.py#L182).
+To install `mgp`, run `pip install mgp`.
 
 Here's the code for the random walk algorithm:
 
@@ -99,3 +96,16 @@ page](/mage/how-to-guides/run-a-query-module).
 Feel free to create an issue or open a pull request on our [GitHub
 repo](https://github.com/memgraph/mage) to speed up the development.<br/>
 Also, don't forget to throw us a star on GitHub. :star:
+
+## Working with the mock API
+
+The
+[mock Python API](https://memgraph.com/docs/memgraph/reference-guide/query-modules/api/mock-python-api)
+lets you develop and test query modules for Memgraph without having to run a
+Memgraph instance. As it’s compatible with the Python API you can add modules
+developed with it to Memgraph as-is, without having to refactor your code.
+
+The documentation on importing the mock API and running query modules with it
+is available
+[here](https://memgraph.com/docs/memgraph/reference-guide/query-modules/api/mock-python-api#using-the-mock-api),
+accompanied by examples.

--- a/mage/usage/loading-modules.md
+++ b/mage/usage/loading-modules.md
@@ -6,9 +6,9 @@ sidebar_label: Loading query modules
 
 import Loading from '../../docs/templates/query-modules/\_loading_query_modules.mdx';
 
-Query modules can be written using C API (thus creating `.so` modules), and
-Python API (thus creating `*.py`) modules. Each file corresponds to one query
-module with one or more procedures within them. The names of these files will be
+Query modules can be written using the C and C++ APIs (creating `.so` modules)
+and the Python API (creating `*.py`) modules. Each file corresponds to one query
+module and contains at least one procedure. The names of these files will be
 mapped to the query module names. For example, a procedure `node_connectivity`
 in `nxalg.py` will be mapped to `nxalg.node_connectivity()` in the Cypher query
 language.
@@ -27,11 +27,11 @@ manage query modules files.
 Here is the list of procedures from the `mg` query module that can be used with
 all other query module files, and their signatures:
 
-| Procedure                                                         | Description                                   |
-| ----------------------------------------------------------------- | --------------------------------------------- |
-| `mg.procedures() -> (name\|STRING, signature\|STRING)`            | Lists loaded procedures and their signatures. |
-| `mg.load(module_name\|STRING) -> ()`                              | Loads or reloads the given module.            |
-| `mg.load_all() -> ()`                                             | Loads or reloads all modules.                 |
+| Procedure                                              | Description                                   |
+| ------------------------------------------------------ | --------------------------------------------- |
+| `mg.procedures() -> (name\|STRING, signature\|STRING)` | Lists loaded procedures and their signatures. |
+| `mg.load(module_name\|STRING) -> ()`                   | Loads or reloads the given module.            |
+| `mg.load_all() -> ()`                                  | Loads or reloads all modules.                 |
 
 ### `mg.procedures`
 

--- a/sidebars/sidebarsMemgraph.js
+++ b/sidebars/sidebarsMemgraph.js
@@ -221,6 +221,7 @@ module.exports = {
               link: { type: "doc", id: "reference-guide/query-modules/implement-custom-query-modules/overview" },
               items: [
                 "reference-guide/query-modules/implement-custom-query-modules/api/python-api",
+                "reference-guide/query-modules/implement-custom-query-modules/api/mock-python-api",
                 "reference-guide/query-modules/implement-custom-query-modules/api/c-api",
                 "reference-guide/query-modules/implement-custom-query-modules/api/cpp-api",
                 "reference-guide/query-modules/implement-custom-query-modules/custom-query-module-example",


### PR DESCRIPTION
### Description

Documentation for [PR#757](https://github.com/memgraph/memgraph/pull/757).

Changelog message (in Major features and improvements):
>  With the new Python mock query module API, you can now develop and test Python query modules for Memgraph without having to run a Memgraph instance. The mock API is compatible with the Python API and thus developed modules can be added to Memgraph as-is.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [x] New documentation page 
- [x] Documentation improvements

### Related PRs and issues

PR this doc page is related to: [PR#757](https://github.com/memgraph/memgraph/pull/757)

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
