### PR TITLE
fix total weight example in ASP doc

### DIFF
--- a/docs/reference-guide/graph-algorithms.md
+++ b/docs/reference-guide/graph-algorithms.md
@@ -363,7 +363,7 @@ RETURN DISTINCT edge;
 
 To get the total weight, add a variable at the end of the expansion expression: 
 ```cypher
-MATCH path=(n {id: 0})-[relationships:CloseTo *WSHORTEST (r, n | 1) total_weight]-(m {id: 9})
+MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | 1) total_weight]-(m {id: 9})
 RETURN nodes(path), total_weight;
 ```
 


### PR DESCRIPTION
### Description

Fixes a cypher example for `*ALLSHORTEST` algorithm here: https://memgraph.com/docs/memgraph/reference-guide/built-in-graph-algorithms#getting-various-results-3 . The example is for `*WSHORTEST`.

### Pull request type

- [x] Documentation fix

### Related PRs and issues

None

### Checklist:

(Not sure that these apply in such a small patch):
- [ ] I checked all content with Grammarly
- [ ] I performed a self-review of my code
- [ ] I made corresponding changes to the rest of the documentation
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
