### PR TITLE
[release-v2.8.0] < [MG-parallelize-index-creation]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,8 +12,6 @@ sidebar_label: Changelog
   [snapshot loading is now distributed among several
   threads](/memgraph/reference-guide/backup#snapshots).
   [#868](https://github.com/memgraph/memgraph/pull/868)
-- Index creation can be done using multiple threads, further speeding up the recovery process.
-  [#882](https://github.com/memgraph/memgraph/pull/882)
 
 ## v2.7 - Apr 5, 2023
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ sidebar_label: Changelog
   [snapshot loading is now distributed among several
   threads](/memgraph/reference-guide/backup#snapshots).
   [#868](https://github.com/memgraph/memgraph/pull/868)
+- Index creation can be done using multiple threads, further speeding up the recovery process.
+  [#882](https://github.com/memgraph/memgraph/pull/882)
 
 ## v2.7 - Apr 5, 2023
 

--- a/docs/reference-guide/configuration.md
+++ b/docs/reference-guide/configuration.md
@@ -66,6 +66,7 @@ workers simultaneously.
 | --storage-wal-file-size-kib=20480 | Minimum file size of each WAL file. | `[uint64]` |
 | --storage-items-per-batch=1000000 | The number of edges and vertices stored in a batch in a snapshot file. | `[uint64]` |
 | --storage-recovery-thread-count= | The number of threads used to recover persisted data from disk. | `[uint64]` |
+| --storage-parallel-index-recovery=false | Controls whether the index creation can be done in a multithreaded fashion. | `[bool]` |
 
 ## Streams
 

--- a/docs/reference-guide/configuration.md
+++ b/docs/reference-guide/configuration.md
@@ -66,7 +66,7 @@ workers simultaneously.
 | --storage-wal-file-size-kib=20480 | Minimum file size of each WAL file. | `[uint64]` |
 | --storage-items-per-batch=1000000 | The number of edges and vertices stored in a batch in a snapshot file. | `[uint64]` |
 | --storage-recovery-thread-count= | The number of threads used to recover persisted data from disk. | `[uint64]` |
-| --storage-parallel-index-recovery=false | Controls whether the index creation can be done in a multithreaded fashion. | `[bool]` |
+| --storage-parallel-index-recovery=false | Controls whether the index creation can be done in a multithreaded fashion during recovery. | `[bool]` |
 
 ## Streams
 


### PR DESCRIPTION
### Description

Update reference guide with the newly added flag that enables/disables using multiple threads of execution for creating indicies.

### Pull request type

- [x] Documentation improvements

### Related PRs and issues

PR this doc page is related to: 
Closes (link to issue):
https://github.com/memgraph/memgraph/pull/882

### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
