### PR TITLE
Add exposing metrics via HTTP endpoint

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,9 +14,10 @@ sidebar_label: Changelog
   [#868](https://github.com/memgraph/memgraph/pull/868)
 - During the recovery, indexes can also  be created using multiple threads, thus
   speeding up the process. [#882](https://github.com/memgraph/memgraph/pull/882)
-- Memgraph now exposes system metrics via an HTTP endpoint, so you can get
-  information about transactions, query latency and various other properties.
-  [#940](https://github.com/memgraph/memgraph/pull/940)
+- In the Enterprise Edition, Memgraph now [exposes system
+  metrics](/reference-guide/exposing-system-metrics.md) via an HTTP endpoint, so
+  you can get information about transactions, query latency and various other
+  properties. [#940](https://github.com/memgraph/memgraph/pull/940)
 - It’s now possible to use the [map projection
   syntax](/memgraph/reference-guide/data-types#maps) to create maps. Map
   projections are convenient for building maps based on existing values and they

--- a/docs/reference-guide/configuration.md
+++ b/docs/reference-guide/configuration.md
@@ -84,12 +84,14 @@ workers simultaneously.
 | --allow-load-csv=true | Controls whether LOAD CSV clause is allowed in queries | `[bool]` |
 | --also-log-to-stderr=false | log messages go to stderr in addition to logfiles | `[bool]` |
 | --data-directory=/var/lib/memgraph | Path to directory in which to save all permanent data. | `[string]` |
-| --init_file | Path to the CYPHERL file which contains queries that need to be executed before the Bolt server starts, such as creating users | `[string]` |
-| --init_data_file | Path to the CYPHERL file, which contains queries that need to be executed after the Bolt server starts | `[string]` |
+| --init-file | Path to the CYPHERL file which contains queries that need to be executed before the Bolt server starts, such as creating users | `[string]` |
+| --init-data-file | Path to the CYPHERL file, which contains queries that need to be executed after the Bolt server starts | `[string]` |
 | --isolation-level=SNAPSHOT_ISOLATION | Isolation level used for the transactions. Allowed values: SNAPSHOT_ISOLATION, READ_COMMITTED, READ_UNCOMMITTED | `[string]` |
 | --log-file=/var/log/memgraph/memgraph.log | Path to where the log should be stored. | `[string]` |
 | --log-level=WARNING | Minimum log level. Allowed values: TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL | `[string]` |
 | --memory-limit=0 | Total memory limit in MiB. Set to 0 to use the default values which are 100% of the physical memory if the swap is enabled and 90% of the physical memory otherwise. | `[uint64]` |
+| --metrics-address | Host for HTTP server for exposing metrics. | `[string]` |
+| --metrics-port | Port for HTTP server for exposing metrics. | `[uint64]` |
 | --memory-warning-threshold=1024 | Memory warning threshold, in MB. If Memgraph detects there is less available RAM it will log a warning. <br/>Set to 0 to disable. | `[uint64]` |
 | --password-encryption-algorithm=bcrypt | Algorithm used for password encryption. Defaults to BCrypt. Allowed values: `bcrypt`, `sha256`, `sha256-multiple` (SHA256 with multiple iterations) | `[string]` |
 | --replication-replica-check-delay-sec | The time duration in seconds between two replica checks/pings. If < 1, replicas will not  be checked at all. The MAIN instance allocates a new thread for each REPLICA. | `[uint64]` |

--- a/docs/reference-guide/enterprise-features.md
+++ b/docs/reference-guide/enterprise-features.md
@@ -32,9 +32,8 @@ auth module. The two supported operation modes are:
   role mapping)
 
 ## Exposing system metrics
-For [exposing system metrics](/reference-guide/exposing-system-metrics.md), we have built
-an HTTP endpoint where system metrics can be fetched via a GET request. The response contains
-information about bolt messages, sessions, transactions, streams, triggers, indexes, snapshots, 
+HTTP endpoint allows you to fetch [system metrics](/reference-guide/exposing-system-metrics.md) using a GET request.
+The response contains information about bolt messages, sessions, transactions, streams, triggers, indexes, snapshots, 
 query latency, and many more.
 
 

--- a/docs/reference-guide/enterprise-features.md
+++ b/docs/reference-guide/enterprise-features.md
@@ -40,3 +40,9 @@ that is packaged with Memgraph Enterprise.
 ## Security
 
 npm
+
+## Exposing system metrics
+For [exposing system metrics](/reference-guide/exposing-system-metrics.md), we have built
+an HTTP endpoint where system metrics can be fetched via a GET request. The response contains
+information about bolt messages, sessions, transactions, streams, triggers, indexes, snapshots, 
+query latency, and many more.

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -16,17 +16,13 @@ After successfully entering the license key, Memgraph needs to be restarted in o
 The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured using [configuration flags](/reference-guide/configuration.md)
 `--metrics-address` and `--metrics-port`. If you need help changing the configuration follow [the how-to guide](/how-to-guides/config-logs.md).
 
-
-## Types of system metrics
+## System metrics
 
 In Memgraph, there are 3 types of metrics that measure different parts of the system in order to ensure proper
 monitoring has been done. Those 3 metrics are:
 - **Gauge** - a single value of some variable in the system (e.g. memory usage)
 - **Counter (uint64_t)** - a value that can be incremented or decremented (e.g. number of active transactions in the system)
 - **Histogram (uint64_t)** - distribution of measured values (e.g. certain percentile of query latency on N measured queries)
-
-
-## System metrics
 
 ### General metrics
 

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -18,8 +18,7 @@ The default address and port for the metrics server is `0.0.0.0:9091`, and can b
 
 ## System metrics
 
-In Memgraph, there are 3 types of metrics that measure different parts of the system in order to ensure proper
-monitoring has been done. Those 3 metrics are:
+All system metrics measuring different parts of the system can be divided into three different types:
 - **Gauge** - a single value of some variable in the system (e.g. memory usage)
 - **Counter (uint64_t)** - a value that can be incremented or decremented (e.g. number of active transactions in the system)
 - **Histogram (uint64_t)** - distribution of measured values (e.g. certain percentile of query latency on N measured queries)

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -1,0 +1,257 @@
+---
+id: exposing-system-metrics
+title: Exposing system metrics (Enterprise)
+sidebar_label: Exposing system metrics
+---
+
+In production systems, monitoring of applications is crucial, and that includes databases as well. Since Memgraph v2.8,
+an HTTP server has been added in order to expose system metrics, giving developers ability to track information about transactions,
+query latencies, snapshot recovery latencies, triggers, bolt messages, indexes, streams, and many more.
+
+## Configuring the HTTP endpoint
+
+Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key.
+After successfully entering the license key, Memgraph would need to be restarted in order to start the metrics HTTP
+server in the following run.
+
+The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured with configuration flags
+`--metrics-address` and `--metrics-port`. For more info on the configuration, check the [list of the configuration variables](/reference-guide/configuration.md).
+
+
+## Types of system metrics
+
+In Memgraph, there are 3 types of metrics that measure different parts of the system in order to ensure proper
+monitoring has been done. Those 3 metrics are:
+- **Gauge** - a single value of some variable in the system (e.g. memory usage)
+- **Counter (uint64_t)** - a value that can be incremented or decremented (e.g. number of active transactions in the system)
+- **Histogram (uint64_t)** - distribution of measured values (e.g. certain percentile of query latency on N measured queries)
+
+
+## List of system metrics
+
+### General metrics
+
+ | Name           | Type             | Description                                                 |
+ | -------------- | ---------------- | ----------------------------------------------------------- |
+ | vertex_count   | Gauge (uint64_t) | Number of nodes stored in the system.                       |
+ | edge_count     | Gauge (uint64_t) | Number of relationships stored in the system.               |
+ | average_degree | Gauge (double)   | Average number of relationships of a single node.           |
+ | memory_usage   | Gauge (uint64_t) | Amount of RAM used reported by the OS (in bytes).           |
+ | disk_usage     | Gauge (uint64_t) | Amount of disk space used by the data directory (in bytes). |
+
+### Index metrics
+
+ | Name                       | Type    | Description                                            |
+ | -------------------------- | ------- | ------------------------------------------------------ |
+ | ActiveLabelIndices         | Counter | Number of active label indices in the system.          |
+ | ActiveLabelPropertyIndices | Counter | Number of active label property indices in the system. |
+
+### Operator metrics
+
+:::info
+
+For more info on operators, check [Inspecting queries](/reference-guide/optimizing-queries/inspecting-queries.md).
+
+:::
+
+ | Name                                | Type    | Description                                                    |
+ | ----------------------------------- | ------- | -------------------------------------------------------------- |
+ | OnceOperator                        | Counter | Number of times Once operator was used.                        |
+ | CreateNodeOperator                  | Counter | Number of times CreateNode operator was used.                  |
+ | CreateExpandOperator                | Counter | Number of times CreateExpand operator was used.                |
+ | ScanAllOperator                     | Counter | Number of times ScanAll operator was used.                     |
+ | ScanAllByLabelOperator              | Counter | Number of times ScanAllByLabel operator was used.              |
+ | ScanAllByLabelPropertyRangeOperator | Counter | Number of times ScanAllByLabelPropertyRange operator was used. |
+ | ScanAllByLabelPropertyValueOperator | Counter | Number of times ScanAllByLabelPropertyValue operator was used. |
+ | ScanAllByLabelPropertyOperator      | Counter | Number of times ScanAllByLabelProperty operator was used.      |
+ | ScanAllByLabelIdOperator            | Counter | Number of times ScanAllByLabelId operator was used.            |
+ | ExpandOperator                      | Counter | Number of times Expand operator was used.                      |
+ | ExpandVariableOperator              | Counter | Number of times ExpandVariable operator was used.              |
+ | ConstructNamedPathOperator          | Counter | Number of times ConstructNamedPath operator was used.          |
+ | FilterOperator                      | Counter | Number of times Filter operator was used.                      |
+ | ProduceOperator                     | Counter | Number of times Produce operator was used.                     |
+ | DeleteOperator                      | Counter | Number of times Delete operator was used.                      |
+ | SetPropertyOperator                 | Counter | Number of times SetProperty operator was used.                 |
+ | SetPropertiesOperator               | Counter | Number of times SetProperties operator was used.               |
+ | SetLabelsOperator                   | Counter | Number of times SetLabels operator was used.                   |
+ | RemovePropertyOperator              | Counter | Number of times RemoveProperty operator was used.              |
+ | RemoveLabelsOperator                | Counter | Number of times RemoveLabels operator was used.                |
+ | EdgeUniquenessFilterOperator        | Counter | Number of times EdgeUniquenessFilter operator was used.        |
+ | EmptyResultOperator                 | Counter | Number of times EmptyResult operator was used.                 |
+ | AccumulateOperator                  | Counter | Number of times Accumulate operator was used.                  |
+ | AggregateOperator                   | Counter | Number of times Aggregate operator was used.                   |
+ | SkipOperator                        | Counter | Number of times Skip operator was used.                        |
+ | LimitOperator                       | Counter | Number of times Limit operator was used.                       |
+ | OrderByOperator                     | Counter | Number of times OrderBy operator was used.                     |
+ | MergeOperator                       | Counter | Number of times Merge operator was used.                       |
+ | OptionalOperator                    | Counter | Number of times Optional operator was used.                    |
+ | UnwindOperator                      | Counter | Number of times Unwind operator was used.                      |
+ | DistinctOperator                    | Counter | Number of times Distinct operator was used.                    |
+ | UnionOperator                       | Counter | Number of times Union operator was used.                       |
+ | CartesianOperator                   | Counter | Number of times Cartesian operator was used.                   |
+ | CallProcedureOperator               | Counter | Number of times CallProcedureOperator operator was used.       |
+ | ForeachOperator                     | Counter | Number of times Foreach operator was used.                     |
+ | EvaluatePatternFilterOperator       | Counter | Number of times EvaluatePatternFilter operator was used.       |
+ | ApplyOperator                       | Counter | Number of times Apply operator was used.                       |
+
+### Query metrics
+
+ | Name                         | Type      | Description                                               |
+ | ---------------------------- | --------- | --------------------------------------------------------- |
+ | QueryExecutionLatency_us_50p | Histogram | Query execution latency in microseconds (50th percentile) |
+ | QueryExecutionLatency_us_90p | Histogram | Query execution latency in microseconds (90th percentile) |
+ | QueryExecutionLatency_us_99p | Histogram | Query execution latency in microseconds (99th percentile) |
+
+### Query type metrics
+
+ | Name           | Type    | Description                            |
+ | -------------- | ------- | -------------------------------------- |
+ | ReadQuery      | Counter | Number of read-only queries executed.  |
+ | WriteQuery     | Counter | Number of write-only queries executed. |
+ | ReadWriteQuery | Counter | Number of read-write queries executed. |
+
+### Session metrics
+
+ | Name                    | Type    | Description                             |
+ | ----------------------- | ------- | --------------------------------------- |
+ | ActiveSessions          | Counter | Number of active connections.           |
+ | ActiveBoltSessions      | Counter | Number of active Bolt connections.      |
+ | ActiveTCPSessions       | Counter | Number of active TCP connections.       |
+ | ActiveSSLSessions       | Counter | Number of active SSL connections.       |
+ | ActiveWebSocketSessions | Counter | Number of active websocket connections. |
+ | BoltMessages            | Counter | Number of Bolt messages sent.           |
+
+### Snapshot metrics
+
+ | Name                           | Type      | Description                                                 |
+ | ------------------------------ | --------- | ----------------------------------------------------------- |
+ | SnapshotCreationLatency_us_50p | Histogram | Snapshot creation latency in microseconds (50th percentile) |
+ | SnapshotCreationLatency_us_90p | Histogram | Snapshot creation latency in microseconds (90th percentile) |
+ | SnapshotCreationLatency_us_99p | Histogram | Snapshot creation latency in microseconds (99th percentile) |
+ | SnapshotRecoveryLatency_us_50p | Histogram | Snapshot recovery latency in microseconds (50th percentile) |
+ | SnapshotRecoveryLatency_us_90p | Histogram | Snapshot recovery latency in microseconds (90th percentile) |
+ | SnapshotRecoveryLatency_us_99p | Histogram | Snapshot recovery latency in microseconds (99th percentile) |
+
+
+### Stream metrics
+
+ | Name             | Type    | Description                           |
+ | ---------------- | ------- | ------------------------------------- |
+ | StreamsCreated   | Counter | Number of streams created.            |
+ | MessagesConsumed | Counter | Number of consumed streamed messages. |
+
+### Transaction metrics
+
+ | Name                   | Type    | Description                                                                     |
+ | ---------------------- | ------- | ------------------------------------------------------------------------------- |
+ | ActiveTransactions     | Counter | Number of active transactions.                                                  |
+ | CommitedTransactions   | Counter | Number of committed transactions.                                               |
+ | RollbackedTransactions | Counter | Number of rollbacked transactions.                                              |
+ | FailedQuery            | Counter | Number of times executing a query failed (either during parse time or runtime). |
+
+### Trigger metrics
+
+ | Name             | Type    | Description                  |
+ | ---------------- | ------- | ---------------------------- |
+ | TriggersCreated  | Counter | Number of Triggers created.  |
+ | TriggersExecuted | Counter | Number of Triggers executed. |
+
+## Example response
+
+If we don't have any modifying configurations, by sending a GET request to `localhost:9091` in the 
+local Memgraph build, we will get response constructed as follows.
+
+```json
+{
+    "General": {
+        "average_degree": 0.0,
+        "disk_usage": 1417846,
+        "edge_count": 0,
+        "memory_usage": 36937728,
+        "vertex_count": 0
+    },
+    "Index": {
+        "ActiveLabelIndices": 0,
+        "ActiveLabelPropertyIndices": 0
+    },
+    "Operator": {
+        "AccumulateOperator": 0,
+        "AggregateOperator": 0,
+        "ApplyOperator": 0,
+        "CallProcedureOperator": 0,
+        "CartesianOperator": 0,
+        "ConstructNamedPathOperator": 0,
+        "CreateExpandOperator": 0,
+        "CreateNodeOperator": 0,
+        "DeleteOperator": 0,
+        "DistinctOperator": 0,
+        "EdgeUniquenessFilterOperator": 0,
+        "EmptyResultOperator": 0,
+        "EvaluatePatternFilterOperator": 0,
+        "ExpandOperator": 0,
+        "ExpandVariableOperator": 0,
+        "FilterOperator": 0,
+        "ForeachOperator": 0,
+        "LimitOperator": 0,
+        "MergeOperator": 0,
+        "OnceOperator": 0,
+        "OptionalOperator": 0,
+        "OrderByOperator": 0,
+        "ProduceOperator": 0,
+        "RemoveLabelsOperator": 0,
+        "RemovePropertyOperator": 0,
+        "ScanAllByIdOperator": 0,
+        "ScanAllByLabelOperator": 0,
+        "ScanAllByLabelPropertyOperator": 0,
+        "ScanAllByLabelPropertyRangeOperator": 0,
+        "ScanAllByLabelPropertyValueOperator": 0,
+        "ScanAllOperator": 0,
+        "SetLabelsOperator": 0,
+        "SetPropertiesOperator": 0,
+        "SetPropertyOperator": 0,
+        "SkipOperator": 0,
+        "UnionOperator": 0,
+        "UnwindOperator": 0
+    },
+    "Query": {
+        "QueryExecutionLatency_us_50p": 0,
+        "QueryExecutionLatency_us_90p": 0,
+        "QueryExecutionLatency_us_99p": 0
+    },
+    "QueryType": {
+        "ReadQuery": 0,
+        "ReadWriteQuery": 0,
+        "WriteQuery": 0
+    },
+    "Session": {
+        "ActiveBoltSessions": 0,
+        "ActiveSSLSessions": 0,
+        "ActiveSessions": 0,
+        "ActiveTCPSessions": 0,
+        "ActiveWebSocketSessions": 0,
+        "BoltMessages": 0
+    },
+    "Snapshot": {
+        "SnapshotCreationLatency_us_50p": 4860,
+        "SnapshotCreationLatency_us_90p": 4860,
+        "SnapshotCreationLatency_us_99p": 4860,
+        "SnapshotRecoveryLatency_us_50p": 628,
+        "SnapshotRecoveryLatency_us_90p": 628,
+        "SnapshotRecoveryLatency_us_99p": 628
+    },
+    "Stream": {
+        "MessagesConsumed": 0,
+        "StreamsCreated": 0
+    },
+    "Transaction": {
+        "ActiveTransactions": 0,
+        "CommitedTransactions": 0,
+        "FailedQuery": 0,
+        "RollbackedTransactions": 0
+    },
+    "Trigger": {
+        "TriggersCreated": 0,
+        "TriggersExecuted": 0
+    }
+}
+```

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -4,14 +4,17 @@ title: Exposing system metrics (Enterprise)
 sidebar_label: Exposing system metrics
 ---
 
-In production systems, monitoring of applications is crucial, and that includes databases as well. Memgraph allows tracking information about transactions, query latencies, snapshot recovery latencies, triggers, bolt messages, indexes, streams, and many more using an HTTP server.
+In production systems, monitoring of applications is crucial, and that includes databases as well. 
+Memgraph allows tracking information about transactions, query latencies, snapshot recovery latencies, 
+triggers, bolt messages, indexes, streams, and many more using an HTTP server.
 
-Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key. After successfully entering the license key, Memgraph needs to be restarted in order to start the metrics HTTP server.
+Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key.
+After successfully entering the license key, Memgraph needs to be restarted in order to start the metrics HTTP server.
 
 ## Configuring the HTTP endpoint
 
-The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured with configuration flags
-`--metrics-address` and `--metrics-port`. For more info on the configuration, check the [list of the configuration variables](/reference-guide/configuration.md).
+The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured using [configuration flags](/reference-guide/configuration.md)
+`--metrics-address` and `--metrics-port`. If you need help changing the configuration follow [the how-to guide](/how-to-guides/config-logs.md).
 
 
 ## Types of system metrics
@@ -23,7 +26,7 @@ monitoring has been done. Those 3 metrics are:
 - **Histogram (uint64_t)** - distribution of measured values (e.g. certain percentile of query latency on N measured queries)
 
 
-## List of system metrics
+## System metrics
 
 ### General metrics
 
@@ -33,7 +36,7 @@ monitoring has been done. Those 3 metrics are:
  | edge_count     | Gauge (uint64_t) | Number of relationships stored in the system.               |
  | average_degree | Gauge (double)   | Average number of relationships of a single node.           |
  | memory_usage   | Gauge (uint64_t) | Amount of RAM used reported by the OS (in bytes).           |
- | disk_usage     | Gauge (uint64_t) | Amount of disk space used by the data directory (in bytes). |
+ | disk_usage     | Gauge (uint64_t) | Amount of disk space used by the [data directory](/reference-guide/backup.md) (in bytes). |
 
 ### Index metrics
 
@@ -44,11 +47,10 @@ monitoring has been done. Those 3 metrics are:
 
 ### Operator metrics
 
-:::info
-
-For more info on operators, check [Inspecting queries](/reference-guide/optimizing-queries/inspecting-queries.md).
-
-:::
+Before a Cypher query is executed, it is converted into an internal form suitable for execution, known as a query plan.
+A query plan is a tree-like data structure describing a pipeline of operations that will be performed on the database in order to
+yield the results for a given query. Every node within a plan is known as
+[a logical operator](/memgraph/reference-guide/inspecting-queries#operators) and describes a particular operation.
 
  | Name                                | Type    | Description                                                    |
  | ----------------------------------- | ------- | -------------------------------------------------------------- |
@@ -92,11 +94,11 @@ For more info on operators, check [Inspecting queries](/reference-guide/optimizi
 
 ### Query metrics
 
- | Name                         | Type      | Description                                               |
- | ---------------------------- | --------- | --------------------------------------------------------- |
- | QueryExecutionLatency_us_50p | Histogram | Query execution latency in microseconds (50th percentile) |
- | QueryExecutionLatency_us_90p | Histogram | Query execution latency in microseconds (90th percentile) |
- | QueryExecutionLatency_us_99p | Histogram | Query execution latency in microseconds (99th percentile) |
+ | Name                         | Type      | Description                                                |
+ | ---------------------------- | --------- | ---------------------------------------------------------- |
+ | QueryExecutionLatency_us_50p | Histogram | Query execution latency in microseconds (50th percentile). |
+ | QueryExecutionLatency_us_90p | Histogram | Query execution latency in microseconds (90th percentile). |
+ | QueryExecutionLatency_us_99p | Histogram | Query execution latency in microseconds (99th percentile). |
 
 ### Query type metrics
 
@@ -119,14 +121,14 @@ For more info on operators, check [Inspecting queries](/reference-guide/optimizi
 
 ### Snapshot metrics
 
- | Name                           | Type      | Description                                                 |
- | ------------------------------ | --------- | ----------------------------------------------------------- |
- | SnapshotCreationLatency_us_50p | Histogram | Snapshot creation latency in microseconds (50th percentile) |
- | SnapshotCreationLatency_us_90p | Histogram | Snapshot creation latency in microseconds (90th percentile) |
- | SnapshotCreationLatency_us_99p | Histogram | Snapshot creation latency in microseconds (99th percentile) |
- | SnapshotRecoveryLatency_us_50p | Histogram | Snapshot recovery latency in microseconds (50th percentile) |
- | SnapshotRecoveryLatency_us_90p | Histogram | Snapshot recovery latency in microseconds (90th percentile) |
- | SnapshotRecoveryLatency_us_99p | Histogram | Snapshot recovery latency in microseconds (99th percentile) |
+ | Name                           | Type      | Description                                                  |
+ | ------------------------------ | --------- | ------------------------------------------------------------ |
+ | SnapshotCreationLatency_us_50p | Histogram | Snapshot creation latency in microseconds (50th percentile). |
+ | SnapshotCreationLatency_us_90p | Histogram | Snapshot creation latency in microseconds (90th percentile)- |
+ | SnapshotCreationLatency_us_99p | Histogram | Snapshot creation latency in microseconds (99th percentile). |
+ | SnapshotRecoveryLatency_us_50p | Histogram | Snapshot recovery latency in microseconds (50th percentile). |
+ | SnapshotRecoveryLatency_us_90p | Histogram | Snapshot recovery latency in microseconds (90th percentile). |
+ | SnapshotRecoveryLatency_us_99p | Histogram | Snapshot recovery latency in microseconds (99th percentile). |
 
 
 ### Stream metrics
@@ -154,8 +156,8 @@ For more info on operators, check [Inspecting queries](/reference-guide/optimizi
 
 ## Example response
 
-If we don't have any modifying configurations, by sending a GET request to `localhost:9091` in the 
-local Memgraph build, we will get response constructed as follows.
+If there aren't any modifying configurations, by sending a GET request to `localhost:9091` in the 
+local Memgraph build will result in a response similar to the one below.
 
 ```json
 {

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -4,9 +4,9 @@ title: Exposing system metrics (Enterprise)
 sidebar_label: Exposing system metrics
 ---
 
-In production systems, monitoring of applications is crucial, and that includes databases as well. Since Memgraph v2.8,
-an HTTP server has been added in order to expose system metrics, giving developers ability to track information about transactions,
-query latencies, snapshot recovery latencies, triggers, bolt messages, indexes, streams, and many more.
+In production systems, monitoring of applications is crucial, and that includes databases as well. Memgraph allows tracking information about transactions, query latencies, snapshot recovery latencies, triggers, bolt messages, indexes, streams, and many more using an HTTP server.
+
+Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key. After successfully entering the license key, Memgraph needs to be restarted in order to start the metrics HTTP server.
 
 ## Configuring the HTTP endpoint
 

--- a/docs/reference-guide/exposing-system-metrics.md
+++ b/docs/reference-guide/exposing-system-metrics.md
@@ -10,10 +10,6 @@ Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Me
 
 ## Configuring the HTTP endpoint
 
-Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key.
-After successfully entering the license key, Memgraph would need to be restarted in order to start the metrics HTTP
-server in the following run.
-
 The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured with configuration flags
 `--metrics-address` and `--metrics-port`. For more info on the configuration, check the [list of the configuration variables](/reference-guide/configuration.md).
 

--- a/docs/reference-guide/optimizing-queries/inspecting-queries.md
+++ b/docs/reference-guide/optimizing-queries/inspecting-queries.md
@@ -26,6 +26,7 @@ produced plan and gain insight into the execution of a query.
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Accumulate`                    | Accumulates the input it received.                                                                                       |
 | `Aggregate`                     | Aggregates the input it received.                                                                                        |
+| `Apply`                         | Joins the returned symbols from  two branches of execution.                                                              |
 | `CallProcedure`                 | Calls a procedure.                                                                                                       |
 | `Cartesian`                     | Applies the Cartesian product (the set of all possible ordered combinations consisting of one member from each of those sets) on the input it received. |
 | `ConstructNamedPath`            | Creates a path.                                                                                                          |
@@ -34,6 +35,7 @@ produced plan and gain insight into the execution of a query.
 | `Delete`                        | Deletes nodes and edges.                                                                                                 |
 | `EdgeUniquenessFilter`          | Filters unique edges.                                                                                                    |
 | `EmptyResult`                   | Discards results from the previous operator.                 |
+| `EvaluatePatternFilter`         | Part of the filter operator that contains a sub-branch which yields either true or false.                                |
 | `Expand`                        | Expands the node by finding the node's relationships.                                                                    |
 | `ExpandVariable`                | Performs a node expansion of a variable number of relationships                                                          |
 | `Filter`                        | Filters the input it received.                                                                                           |

--- a/docs/reference-guide/optimizing-queries/inspecting-queries.md
+++ b/docs/reference-guide/optimizing-queries/inspecting-queries.md
@@ -26,7 +26,7 @@ produced plan and gain insight into the execution of a query.
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Accumulate`                    | Accumulates the input it received.                                                                                       |
 | `Aggregate`                     | Aggregates the input it received.                                                                                        |
-| `Apply`                         | Joins the returned symbols from  two branches of execution.                                                              |
+| `Apply`                         | Joins the returned symbols from two branches of execution.                                                              |
 | `CallProcedure`                 | Calls a procedure.                                                                                                       |
 | `Cartesian`                     | Applies the Cartesian product (the set of all possible ordered combinations consisting of one member from each of those sets) on the input it received. |
 | `ConstructNamedPath`            | Creates a path.                                                                                                          |

--- a/memgraph_versioned_docs/version-2.8.0/changelog.md
+++ b/memgraph_versioned_docs/version-2.8.0/changelog.md
@@ -14,9 +14,10 @@ sidebar_label: Changelog
   [#868](https://github.com/memgraph/memgraph/pull/868)
 - During the recovery, indexes can also  be created using multiple threads, thus
   speeding up the process. [#882](https://github.com/memgraph/memgraph/pull/882)
-- Memgraph now exposes system metrics via an HTTP endpoint, so you can get
-  information about transactions, query latency and various other properties.
-  [#940](https://github.com/memgraph/memgraph/pull/940)
+- In the Enterprise Edition, Memgraph now [exposes system
+  metrics](/reference-guide/exposing-system-metrics.md) via an HTTP endpoint, so
+  you can get information about transactions, query latency and various other
+  properties. [#940](https://github.com/memgraph/memgraph/pull/940)
 - It’s now possible to use the [map projection
   syntax](/memgraph/reference-guide/data-types#maps) to create maps. Map
   projections are convenient for building maps based on existing values and they

--- a/memgraph_versioned_docs/version-2.8.0/reference-guide/configuration.md
+++ b/memgraph_versioned_docs/version-2.8.0/reference-guide/configuration.md
@@ -84,12 +84,14 @@ workers simultaneously.
 | --allow-load-csv=true | Controls whether LOAD CSV clause is allowed in queries | `[bool]` |
 | --also-log-to-stderr=false | log messages go to stderr in addition to logfiles | `[bool]` |
 | --data-directory=/var/lib/memgraph | Path to directory in which to save all permanent data. | `[string]` |
-| --init_file | Path to the CYPHERL file which contains queries that need to be executed before the Bolt server starts, such as creating users | `[string]` |
-| --init_data_file | Path to the CYPHERL file, which contains queries that need to be executed after the Bolt server starts | `[string]` |
+| --init-file | Path to the CYPHERL file which contains queries that need to be executed before the Bolt server starts, such as creating users | `[string]` |
+| --init-data-file | Path to the CYPHERL file, which contains queries that need to be executed after the Bolt server starts | `[string]` |
 | --isolation-level=SNAPSHOT_ISOLATION | Isolation level used for the transactions. Allowed values: SNAPSHOT_ISOLATION, READ_COMMITTED, READ_UNCOMMITTED | `[string]` |
 | --log-file=/var/log/memgraph/memgraph.log | Path to where the log should be stored. | `[string]` |
 | --log-level=WARNING | Minimum log level. Allowed values: TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL | `[string]` |
 | --memory-limit=0 | Total memory limit in MiB. Set to 0 to use the default values which are 100% of the physical memory if the swap is enabled and 90% of the physical memory otherwise. | `[uint64]` |
+| --metrics-address | Host for HTTP server for exposing metrics. | `[string]` |
+| --metrics-port | Port for HTTP server for exposing metrics. | `[uint64]` |
 | --memory-warning-threshold=1024 | Memory warning threshold, in MB. If Memgraph detects there is less available RAM it will log a warning. <br/>Set to 0 to disable. | `[uint64]` |
 | --password-encryption-algorithm=bcrypt | Algorithm used for password encryption. Defaults to BCrypt. Allowed values: `bcrypt`, `sha256`, `sha256-multiple` (SHA256 with multiple iterations) | `[string]` |
 | --replication-replica-check-delay-sec | The time duration in seconds between two replica checks/pings. If < 1, replicas will not  be checked at all. The MAIN instance allocates a new thread for each REPLICA. | `[uint64]` |

--- a/memgraph_versioned_docs/version-2.8.0/reference-guide/enterprise-features.md
+++ b/memgraph_versioned_docs/version-2.8.0/reference-guide/enterprise-features.md
@@ -31,6 +31,12 @@ auth module. The two supported operation modes are:
 - authentication and authorization (username/password verification and user to
   role mapping)
 
+## Exposing system metrics
+HTTP endpoint allows you to fetch [system
+metrics](/reference-guide/exposing-system-metrics.md) using a GET request. The
+response contains information about bolt messages, sessions, transactions,
+streams, triggers, indexes, snapshots, query latency, and many more.
+
 ## LDAP Security
 
 For the purpose of supporting [LDAP authentication and (optional)

--- a/memgraph_versioned_docs/version-2.8.0/reference-guide/exposing-system-metrics.md
+++ b/memgraph_versioned_docs/version-2.8.0/reference-guide/exposing-system-metrics.md
@@ -1,0 +1,250 @@
+---
+id: exposing-system-metrics
+title: Exposing system metrics (Enterprise)
+sidebar_label: Exposing system metrics
+---
+
+In production systems, monitoring of applications is crucial, and that includes databases as well. 
+Memgraph allows tracking information about transactions, query latencies, snapshot recovery latencies, 
+triggers, bolt messages, indexes, streams, and many more using an HTTP server.
+
+Exposing metrics is a Memgraph Enterprise feature and therefore needs a valid Memgraph Enterprise license key.
+After successfully entering the license key, Memgraph needs to be restarted in order to start the metrics HTTP server.
+
+## Configuring the HTTP endpoint
+
+The default address and port for the metrics server is `0.0.0.0:9091`, and can be configured using [configuration flags](/reference-guide/configuration.md)
+`--metrics-address` and `--metrics-port`. If you need help changing the configuration follow [the how-to guide](/how-to-guides/config-logs.md).
+
+## System metrics
+
+All system metrics measuring different parts of the system can be divided into three different types:
+- **Gauge** - a single value of some variable in the system (e.g. memory usage)
+- **Counter (uint64_t)** - a value that can be incremented or decremented (e.g. number of active transactions in the system)
+- **Histogram (uint64_t)** - distribution of measured values (e.g. certain percentile of query latency on N measured queries)
+
+### General metrics
+
+ | Name           | Type             | Description                                                 |
+ | -------------- | ---------------- | ----------------------------------------------------------- |
+ | vertex_count   | Gauge (uint64_t) | Number of nodes stored in the system.                       |
+ | edge_count     | Gauge (uint64_t) | Number of relationships stored in the system.               |
+ | average_degree | Gauge (double)   | Average number of relationships of a single node.           |
+ | memory_usage   | Gauge (uint64_t) | Amount of RAM used reported by the OS (in bytes).           |
+ | disk_usage     | Gauge (uint64_t) | Amount of disk space used by the [data directory](/reference-guide/backup.md) (in bytes). |
+
+### Index metrics
+
+ | Name                       | Type    | Description                                            |
+ | -------------------------- | ------- | ------------------------------------------------------ |
+ | ActiveLabelIndices         | Counter | Number of active label indices in the system.          |
+ | ActiveLabelPropertyIndices | Counter | Number of active label property indices in the system. |
+
+### Operator metrics
+
+Before a Cypher query is executed, it is converted into an internal form suitable for execution, known as a query plan.
+A query plan is a tree-like data structure describing a pipeline of operations that will be performed on the database in order to
+yield the results for a given query. Every node within a plan is known as
+[a logical operator](/memgraph/reference-guide/inspecting-queries#operators) and describes a particular operation.
+
+ | Name                                | Type    | Description                                                    |
+ | ----------------------------------- | ------- | -------------------------------------------------------------- |
+ | OnceOperator                        | Counter | Number of times Once operator was used.                        |
+ | CreateNodeOperator                  | Counter | Number of times CreateNode operator was used.                  |
+ | CreateExpandOperator                | Counter | Number of times CreateExpand operator was used.                |
+ | ScanAllOperator                     | Counter | Number of times ScanAll operator was used.                     |
+ | ScanAllByLabelOperator              | Counter | Number of times ScanAllByLabel operator was used.              |
+ | ScanAllByLabelPropertyRangeOperator | Counter | Number of times ScanAllByLabelPropertyRange operator was used. |
+ | ScanAllByLabelPropertyValueOperator | Counter | Number of times ScanAllByLabelPropertyValue operator was used. |
+ | ScanAllByLabelPropertyOperator      | Counter | Number of times ScanAllByLabelProperty operator was used.      |
+ | ScanAllByLabelIdOperator            | Counter | Number of times ScanAllByLabelId operator was used.            |
+ | ExpandOperator                      | Counter | Number of times Expand operator was used.                      |
+ | ExpandVariableOperator              | Counter | Number of times ExpandVariable operator was used.              |
+ | ConstructNamedPathOperator          | Counter | Number of times ConstructNamedPath operator was used.          |
+ | FilterOperator                      | Counter | Number of times Filter operator was used.                      |
+ | ProduceOperator                     | Counter | Number of times Produce operator was used.                     |
+ | DeleteOperator                      | Counter | Number of times Delete operator was used.                      |
+ | SetPropertyOperator                 | Counter | Number of times SetProperty operator was used.                 |
+ | SetPropertiesOperator               | Counter | Number of times SetProperties operator was used.               |
+ | SetLabelsOperator                   | Counter | Number of times SetLabels operator was used.                   |
+ | RemovePropertyOperator              | Counter | Number of times RemoveProperty operator was used.              |
+ | RemoveLabelsOperator                | Counter | Number of times RemoveLabels operator was used.                |
+ | EdgeUniquenessFilterOperator        | Counter | Number of times EdgeUniquenessFilter operator was used.        |
+ | EmptyResultOperator                 | Counter | Number of times EmptyResult operator was used.                 |
+ | AccumulateOperator                  | Counter | Number of times Accumulate operator was used.                  |
+ | AggregateOperator                   | Counter | Number of times Aggregate operator was used.                   |
+ | SkipOperator                        | Counter | Number of times Skip operator was used.                        |
+ | LimitOperator                       | Counter | Number of times Limit operator was used.                       |
+ | OrderByOperator                     | Counter | Number of times OrderBy operator was used.                     |
+ | MergeOperator                       | Counter | Number of times Merge operator was used.                       |
+ | OptionalOperator                    | Counter | Number of times Optional operator was used.                    |
+ | UnwindOperator                      | Counter | Number of times Unwind operator was used.                      |
+ | DistinctOperator                    | Counter | Number of times Distinct operator was used.                    |
+ | UnionOperator                       | Counter | Number of times Union operator was used.                       |
+ | CartesianOperator                   | Counter | Number of times Cartesian operator was used.                   |
+ | CallProcedureOperator               | Counter | Number of times CallProcedureOperator operator was used.       |
+ | ForeachOperator                     | Counter | Number of times Foreach operator was used.                     |
+ | EvaluatePatternFilterOperator       | Counter | Number of times EvaluatePatternFilter operator was used.       |
+ | ApplyOperator                       | Counter | Number of times Apply operator was used.                       |
+
+### Query metrics
+
+ | Name                         | Type      | Description                                                |
+ | ---------------------------- | --------- | ---------------------------------------------------------- |
+ | QueryExecutionLatency_us_50p | Histogram | Query execution latency in microseconds (50th percentile). |
+ | QueryExecutionLatency_us_90p | Histogram | Query execution latency in microseconds (90th percentile). |
+ | QueryExecutionLatency_us_99p | Histogram | Query execution latency in microseconds (99th percentile). |
+
+### Query type metrics
+
+ | Name           | Type    | Description                            |
+ | -------------- | ------- | -------------------------------------- |
+ | ReadQuery      | Counter | Number of read-only queries executed.  |
+ | WriteQuery     | Counter | Number of write-only queries executed. |
+ | ReadWriteQuery | Counter | Number of read-write queries executed. |
+
+### Session metrics
+
+ | Name                    | Type    | Description                             |
+ | ----------------------- | ------- | --------------------------------------- |
+ | ActiveSessions          | Counter | Number of active connections.           |
+ | ActiveBoltSessions      | Counter | Number of active Bolt connections.      |
+ | ActiveTCPSessions       | Counter | Number of active TCP connections.       |
+ | ActiveSSLSessions       | Counter | Number of active SSL connections.       |
+ | ActiveWebSocketSessions | Counter | Number of active websocket connections. |
+ | BoltMessages            | Counter | Number of Bolt messages sent.           |
+
+### Snapshot metrics
+
+ | Name                           | Type      | Description                                                  |
+ | ------------------------------ | --------- | ------------------------------------------------------------ |
+ | SnapshotCreationLatency_us_50p | Histogram | Snapshot creation latency in microseconds (50th percentile). |
+ | SnapshotCreationLatency_us_90p | Histogram | Snapshot creation latency in microseconds (90th percentile)- |
+ | SnapshotCreationLatency_us_99p | Histogram | Snapshot creation latency in microseconds (99th percentile). |
+ | SnapshotRecoveryLatency_us_50p | Histogram | Snapshot recovery latency in microseconds (50th percentile). |
+ | SnapshotRecoveryLatency_us_90p | Histogram | Snapshot recovery latency in microseconds (90th percentile). |
+ | SnapshotRecoveryLatency_us_99p | Histogram | Snapshot recovery latency in microseconds (99th percentile). |
+
+
+### Stream metrics
+
+ | Name             | Type    | Description                           |
+ | ---------------- | ------- | ------------------------------------- |
+ | StreamsCreated   | Counter | Number of streams created.            |
+ | MessagesConsumed | Counter | Number of consumed streamed messages. |
+
+### Transaction metrics
+
+ | Name                   | Type    | Description                                                                     |
+ | ---------------------- | ------- | ------------------------------------------------------------------------------- |
+ | ActiveTransactions     | Counter | Number of active transactions.                                                  |
+ | CommitedTransactions   | Counter | Number of committed transactions.                                               |
+ | RollbackedTransactions | Counter | Number of rollbacked transactions.                                              |
+ | FailedQuery            | Counter | Number of times executing a query failed (either during parse time or runtime). |
+
+### Trigger metrics
+
+ | Name             | Type    | Description                  |
+ | ---------------- | ------- | ---------------------------- |
+ | TriggersCreated  | Counter | Number of Triggers created.  |
+ | TriggersExecuted | Counter | Number of Triggers executed. |
+
+## Example response
+
+If there aren't any modifying configurations, by sending a GET request to `localhost:9091` in the 
+local Memgraph build will result in a response similar to the one below.
+
+```json
+{
+    "General": {
+        "average_degree": 0.0,
+        "disk_usage": 1417846,
+        "edge_count": 0,
+        "memory_usage": 36937728,
+        "vertex_count": 0
+    },
+    "Index": {
+        "ActiveLabelIndices": 0,
+        "ActiveLabelPropertyIndices": 0
+    },
+    "Operator": {
+        "AccumulateOperator": 0,
+        "AggregateOperator": 0,
+        "ApplyOperator": 0,
+        "CallProcedureOperator": 0,
+        "CartesianOperator": 0,
+        "ConstructNamedPathOperator": 0,
+        "CreateExpandOperator": 0,
+        "CreateNodeOperator": 0,
+        "DeleteOperator": 0,
+        "DistinctOperator": 0,
+        "EdgeUniquenessFilterOperator": 0,
+        "EmptyResultOperator": 0,
+        "EvaluatePatternFilterOperator": 0,
+        "ExpandOperator": 0,
+        "ExpandVariableOperator": 0,
+        "FilterOperator": 0,
+        "ForeachOperator": 0,
+        "LimitOperator": 0,
+        "MergeOperator": 0,
+        "OnceOperator": 0,
+        "OptionalOperator": 0,
+        "OrderByOperator": 0,
+        "ProduceOperator": 0,
+        "RemoveLabelsOperator": 0,
+        "RemovePropertyOperator": 0,
+        "ScanAllByIdOperator": 0,
+        "ScanAllByLabelOperator": 0,
+        "ScanAllByLabelPropertyOperator": 0,
+        "ScanAllByLabelPropertyRangeOperator": 0,
+        "ScanAllByLabelPropertyValueOperator": 0,
+        "ScanAllOperator": 0,
+        "SetLabelsOperator": 0,
+        "SetPropertiesOperator": 0,
+        "SetPropertyOperator": 0,
+        "SkipOperator": 0,
+        "UnionOperator": 0,
+        "UnwindOperator": 0
+    },
+    "Query": {
+        "QueryExecutionLatency_us_50p": 0,
+        "QueryExecutionLatency_us_90p": 0,
+        "QueryExecutionLatency_us_99p": 0
+    },
+    "QueryType": {
+        "ReadQuery": 0,
+        "ReadWriteQuery": 0,
+        "WriteQuery": 0
+    },
+    "Session": {
+        "ActiveBoltSessions": 0,
+        "ActiveSSLSessions": 0,
+        "ActiveSessions": 0,
+        "ActiveTCPSessions": 0,
+        "ActiveWebSocketSessions": 0,
+        "BoltMessages": 0
+    },
+    "Snapshot": {
+        "SnapshotCreationLatency_us_50p": 4860,
+        "SnapshotCreationLatency_us_90p": 4860,
+        "SnapshotCreationLatency_us_99p": 4860,
+        "SnapshotRecoveryLatency_us_50p": 628,
+        "SnapshotRecoveryLatency_us_90p": 628,
+        "SnapshotRecoveryLatency_us_99p": 628
+    },
+    "Stream": {
+        "MessagesConsumed": 0,
+        "StreamsCreated": 0
+    },
+    "Transaction": {
+        "ActiveTransactions": 0,
+        "CommitedTransactions": 0,
+        "FailedQuery": 0,
+        "RollbackedTransactions": 0
+    },
+    "Trigger": {
+        "TriggersCreated": 0,
+        "TriggersExecuted": 0
+    }
+}
+```

--- a/memgraph_versioned_docs/version-2.8.0/reference-guide/optimizing-queries/inspecting-queries.md
+++ b/memgraph_versioned_docs/version-2.8.0/reference-guide/optimizing-queries/inspecting-queries.md
@@ -26,6 +26,7 @@ produced plan and gain insight into the execution of a query.
 | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Accumulate`                    | Accumulates the input it received.                                                                                       |
 | `Aggregate`                     | Aggregates the input it received.                                                                                        |
+| `Apply`                         | Joins the returned symbols from two branches of execution.                                                               |
 | `CallProcedure`                 | Calls a procedure.                                                                                                       |
 | `Cartesian`                     | Applies the Cartesian product (the set of all possible ordered combinations consisting of one member from each of those sets) on the input it received. |
 | `ConstructNamedPath`            | Creates a path.                                                                                                          |
@@ -33,7 +34,8 @@ produced plan and gain insight into the execution of a query.
 | `CreateExpand`                  | Creates edges and  new nodes to connect with existing nodes.                                                             |
 | `Delete`                        | Deletes nodes and edges.                                                                                                 |
 | `EdgeUniquenessFilter`          | Filters unique edges.                                                                                                    |
-| `EmptyResult`                   | Discards results from the previous operator.                 |
+| `EmptyResult`                   | Discards results from the previous operator.                                                                             |
+| `EvaluatePatternFilter`         | Part of the filter operator that contains a sub-branch which yields either true or false.                                |
 | `Expand`                        | Expands the node by finding the node's relationships.                                                                    |
 | `ExpandVariable`                | Performs a node expansion of a variable number of relationships                                                          |
 | `Filter`                        | Filters the input it received.                                                                                           |

--- a/memgraph_versioned_sidebars/version-2.8.0-sidebars.json
+++ b/memgraph_versioned_sidebars/version-2.8.0-sidebars.json
@@ -314,6 +314,7 @@
             "reference-guide/enabling-enterprise",
             "reference-guide/audit-log",
             "reference-guide/auth-module",
+            "reference-guide/exposing-system-metrics",
             "reference-guide/ldap-security",
             "reference-guide/security"
           ]

--- a/sidebars/sidebarsMemgraph.js
+++ b/sidebars/sidebarsMemgraph.js
@@ -266,6 +266,7 @@ module.exports = {
             "reference-guide/enabling-enterprise",
             "reference-guide/audit-log",
             "reference-guide/auth-module",
+            "reference-guide/exposing-system-metrics",
             "reference-guide/ldap-security",
             "reference-guide/security",
           ],


### PR DESCRIPTION
### Description

Docs explain the new feature in Memgraph v2.8 - exposing system metrics via an HTTP endpoint. With this feature, users are able to get metrics about various information in the system (info about transactions, streams, query latencies, indexes, etc.) so they can react properly and be aware to changes in the system

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [X] New documentation page 

### Checklist:

- [X] I checked all content with Grammarly
- [X] I performed a self-review of my code
- [X] I made corresponding changes to the rest of the documentation
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
