### PR TITLE
[master < fiy-typo-20230524] Fix typo in mgconsole flag documentation

### DIFF
--- a/docs/connect-to-memgraph/mgconsole.md
+++ b/docs/connect-to-memgraph/mgconsole.md
@@ -201,7 +201,7 @@ Below are configurational flags you can use with mgconsole:
 | -history                  | Use the specified directory to save history.                                                                         | string  | "~/.memgraph" |
 | -host                     | Server address. It can be a DNS resolvable hostname.                                                                     | string  | "127.0.0.1" |
 | -no_history               | Do not save history.                                                                                                    | bool    | false   |
-| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit-to-screen` flag is ignored.       | string  | "tabular" |
+| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit_to_screen` flag is ignored.       | string  | "tabular" |
 | -password                 | Database password.                                                                                               | string  | ""      |
 | -port                     | Server port.                                                                                                             | int32   | 7687    |
 | -term_colors              | Use terminal colors syntax highlighting.                                                                                | bool    | false   |

--- a/memgraph_versioned_docs/version-2.7.0/connect-to-memgraph/mgconsole.md
+++ b/memgraph_versioned_docs/version-2.7.0/connect-to-memgraph/mgconsole.md
@@ -204,7 +204,7 @@ Below are configurational flags you can use with mgconsole:
 | -history                  | Use the specified directory to save history.                                                                         | string  | "~/.memgraph" |
 | -host                     | Server address. It can be a DNS resolvable hostname.                                                                     | string  | "127.0.0.1" |
 | -no_history               | Do not save history.                                                                                                    | bool    | false   |
-| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit-to-screen` flag is ignored.       | string  | "tabular" |
+| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit_to_screen` flag is ignored.       | string  | "tabular" |
 | -password                 | Database password.                                                                                               | string  | ""      |
 | -port                     | Server port.                                                                                                             | int32   | 7687    |
 | -term_colors              | Use terminal colors syntax highlighting.                                                                                | bool    | false   |

--- a/memgraph_versioned_docs/version-2.8.0/connect-to-memgraph/mgconsole.md
+++ b/memgraph_versioned_docs/version-2.8.0/connect-to-memgraph/mgconsole.md
@@ -201,7 +201,7 @@ Below are configurational flags you can use with mgconsole:
 | -history                  | Use the specified directory to save history.                                                                         | string  | "~/.memgraph" |
 | -host                     | Server address. It can be a DNS resolvable hostname.                                                                     | string  | "127.0.0.1" |
 | -no_history               | Do not save history.                                                                                                    | bool    | false   |
-| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit-to-screen` flag is ignored.       | string  | "tabular" |
+| -output_format            | Query output format. Can be `csv` or `tabular`. If the output format is not tabular `fit_to_screen` flag is ignored.       | string  | "tabular" |
 | -password                 | Database password.                                                                                               | string  | ""      |
 | -port                     | Server port.                                                                                                             | int32   | 7687    |
 | -term_colors              | Use terminal colors syntax highlighting.                                                                                | bool    | false   |


### PR DESCRIPTION
### Description

Fixed typo in mgconsole flag documentation.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [ ] Documentation fix

### Related PRs and issues

PR this doc page is related to: 
Closes (link to issue):


### Checklist:

- [ ] I checked all content with Grammarly
- [ ] I performed a self-review of my code
- [ ] I made corresponding changes to the rest of the documentation
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
