### PR TITLE
[master < ] Transaction metadata

### DIFF
--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -47,6 +47,12 @@ The command will show only the transactions you started or transactions for whic
 
 <img src={require('../data/how-to-guides/manage-transactional-queue/show_transactions.png').default}/>
 
+### Distinguish between transactions
+
+Since Memgraph v2.9.0, users can pass additional metadata when starting a transaction. 
+The `SHOW TRANSACTIONS;` returns the user-defined transaction metadata.
+This way, each unique transaction is easily identifiable.
+
 ### Terminate transactions
 
 To terminate one or more transactions, you need to open a new session and use the following query:

--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -33,23 +33,25 @@ Roll back unsuccessful transactions by executing the `ROLLBACK;` query.
 
 ## Managing transactions
 
-Starting with Memgraph v2.7.0 you can check running transactions and terminate them.
+Memgraph can return information about running transactions and allow you to terminate them. 
 
-### Show transactions
+### Get information about transaction
 
-To see what transactions are running at the moment use the following command:
+To get information about running transaction execute the following query: 
 
 ```cypher
 SHOW TRANSACTIONS;
-```
+``` 
 
-The command will show only the transactions you started or transactions for which you have the necessary [privilege](#privileges-needed-to-manage-all-transactions).
+The query shows only the transactions you started or transactions for which you
+have the necessary [privileges](#privileges-needed-to-manage-all-transactions).
 
 <img src={require('../data/how-to-guides/manage-transactional-queue/show_transactions.png').default}/>
 
-### Distinguish between transactions
-
-You can pass additional metadata when starting a transaction which will be visible when running the `SHOW TRANSACTIONS;` query, thus allowing you to identify each transaction precisely.
+If you are connecting to Memgraph using a client, you can pass additional
+metadata when starting a transaction (if the client supports additional
+metadata) which will be visible when running the `SHOW TRANSACTIONS;` query,
+thus allowing you to identify each transaction precisely.
 
 ### Terminate transactions
 
@@ -61,8 +63,11 @@ TERMINATE TRANSACTIONS "tid", "<tid2>", "<tid3>", ... ;
 
 The `tid` is the transactional ID that can be seen using the `SHOW TRANSACTIONS;` query.
 
-The `TERMINATE TRANSACTIONS` query signalizes to the thread executing the transaction that it should stop the execution. No violent interruption will happen, and the whole system will stay in a consistent state.
-To terminate the transaction you haven't started, you need to have the necessary [privilege](#privileges-needed-to-manage-all-transactions).
+The `TERMINATE TRANSACTIONS` query signalizes to the thread executing the
+transaction that it should stop the execution. No violent interruption will
+happen, and the whole system will stay in a consistent state. To terminate the
+transaction you haven't started, you need to have the necessary
+[privileges](#privileges-needed-to-manage-all-transactions).
 
 #### Terminating custom procedures
 
@@ -70,7 +75,29 @@ If you want to be able to [terminate custom
 procedures](/reference-guide/query-modules/implement-custom-query-modules/custom-query-module-example.md),
 crucial parts of the code, such as `while` and `until` loops, or similar points
 where the procedure might become costly, need to be preceded with
-CheckMustAbort() function.
+`CheckMustAbort()` function.
+
+### Privileges needed to manage all transactions
+
+By default, the users can see and terminate only the transactions they started. For all other transactions, the user must have the **TRANSACTION_MANAGEMENT** privilege which the admin assigns with the following query:
+
+```cypher
+GRANT TRANSACTION_MANAGEMENT TO user;
+```
+
+The privilege to see all the transactions running in Memgraph is revoked using the following query:
+
+```cypher
+REVOKE TRANSACTION_MANAGEMENT FROM user;
+```
+
+:::info
+When Memgraph is first started there is only one explicit super-admin user that has all privileges, including the **TRANSACTION_MANAGEMENT**. The super-admin user is able to see all transactions.
+:::
+
+### Example
+
+Managing transactions is done by establishing a new connection to the database. 
 
 #### New session with Docker
 
@@ -94,9 +121,10 @@ If you are using **mgconsole** on an instance running in a Docker container:
 
 4. Run the `SHOW TRANSACTIONS;` and `TERMINATE TRANSACTIONS tid;`
 
-### Example
+#### Show and terminate transactions 
 
-The output of the `SHOW TRANSACTIONS` command shows that an infinite query is currently being run as part of the transaction ID "9223372036854775809".
+The output of the `SHOW TRANSACTIONS` command shows that an infinite query is
+currently being run as part of the transaction ID "9223372036854775809".
 
 To terminate the transaction, run the following query:
 
@@ -111,24 +139,6 @@ Upon the transaction termination, the following confirmation will appear:
 The following message will appear in the session in which the infinite query was being run:
 
 <img src={require('../data/how-to-guides/manage-transactional-queue/transaction_aborted_message.png').default}/>
-
-### Privileges needed to manage all transactions
-
-By default, the users can see and terminate only the transactions they started. For all other transactions, the user must have the **TRANSACTION_MANAGEMENT** privilege which the admin assigns with the following query:
-
-```cypher
-GRANT TRANSACTION_MANAGEMENT TO user;
-```
-
-The privilege to see all the transactions running in Memgraph is revoked using the following query:
-
-```cypher
-REVOKE TRANSACTION_MANAGEMENT FROM user;
-```
-
-:::info
-When Memgraph is first started there is only one explicit super-admin user that has all privileges, including the **TRANSACTION_MANAGEMENT**. The super-admin user is able to see all transactions.
-:::
 
 ## Isolation levels
 

--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -35,7 +35,7 @@ Roll back unsuccessful transactions by executing the `ROLLBACK;` query.
 
 Memgraph can return information about running transactions and allow you to terminate them. 
 
-### Get information about transaction
+### Show running transactions
 
 To get information about running transaction execute the following query: 
 

--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -53,8 +53,8 @@ metadata when starting a transaction (if the client supports additional
 metadata) which will be visible when running the `SHOW TRANSACTIONS;` query,
 thus allowing you to identify each transaction precisely.
 
-Below is a simple python example demonstrating how to pass metadata for
-both an implicit and explicit transaction.
+The Python example below demonstrates how to pass metadata for
+both an implicit and explicit transaction:
 
 ```python
 import neo4j

--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -49,9 +49,7 @@ The command will show only the transactions you started or transactions for whic
 
 ### Distinguish between transactions
 
-Since Memgraph v2.9.0, users can pass additional metadata when starting a transaction. 
-The `SHOW TRANSACTIONS;` returns the user-defined transaction metadata.
-This way, each unique transaction is easily identifiable.
+You can pass additional metadata when starting a transaction which will be visible when running the `SHOW TRANSACTIONS;` query, thus allowing you to identify each transaction precisely.
 
 ### Terminate transactions
 

--- a/docs/reference-guide/transactions.md
+++ b/docs/reference-guide/transactions.md
@@ -33,15 +33,15 @@ Roll back unsuccessful transactions by executing the `ROLLBACK;` query.
 
 ## Managing transactions
 
-Memgraph can return information about running transactions and allow you to terminate them. 
+Memgraph can return information about running transactions and allow you to terminate them.
 
 ### Show running transactions
 
-To get information about running transaction execute the following query: 
+To get information about running transaction execute the following query:
 
 ```cypher
 SHOW TRANSACTIONS;
-``` 
+```
 
 The query shows only the transactions you started or transactions for which you
 have the necessary [privileges](#privileges-needed-to-manage-all-transactions).
@@ -52,6 +52,31 @@ If you are connecting to Memgraph using a client, you can pass additional
 metadata when starting a transaction (if the client supports additional
 metadata) which will be visible when running the `SHOW TRANSACTIONS;` query,
 thus allowing you to identify each transaction precisely.
+
+Below is a simple python example demonstrating how to pass metadata for
+both an implicit and explicit transaction.
+
+```python
+import neo4j
+
+def main():
+  driver = neo4j.GraphDatabase.driver("bolt://localhost:7687", auth=("user","pass"))
+
+  s1 = driver.session()
+  tx = s1.begin_transaction(metadata={"where":"in explicit tx", "my_uuid":1})
+  tx.run("MATCH (n) RETURN n LIMIT 1")
+
+  s2 = driver.session()
+  query=neo4j.Query("SHOW TRANSACTIONS", metadata={"where":"in implicit tx", "my_uuid":2})
+  print(s2.run(query).values())
+
+  tx.close()
+  s1.close()
+  s2.close()
+
+if __name__ == '__main__':
+  main()
+```
 
 ### Terminate transactions
 
@@ -97,7 +122,7 @@ When Memgraph is first started there is only one explicit super-admin user that 
 
 ### Example
 
-Managing transactions is done by establishing a new connection to the database. 
+Managing transactions is done by establishing a new connection to the database.
 
 #### New session with Docker
 
@@ -121,7 +146,7 @@ If you are using **mgconsole** on an instance running in a Docker container:
 
 4. Run the `SHOW TRANSACTIONS;` and `TERMINATE TRANSACTIONS tid;`
 
-#### Show and terminate transactions 
+#### Show and terminate transactions
 
 The output of the `SHOW TRANSACTIONS` command shows that an infinite query is
 currently being run as part of the transaction ID "9223372036854775809".


### PR DESCRIPTION
### Description

We added support for user-defined transaction metadata. The user can pass additional information via a dictionary. 
This was implemented because users complained that distinguishing between multiple similar transactions was difficult.
Now they can add a uuid to each transaction, call show transaction and filter out the exact transaction they are interested in.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [ ] Documentation improvements

### Related PRs and issues

PR this doc page is related to: 
https://github.com/memgraph/memgraph/pull/945

### Checklist:

- [ ] I checked all content with Grammarly
- [ ] I performed a self-review of my code
- [ ] I made corresponding changes to the rest of the documentation
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
