### PR TITLE
[master < T922] Add documentation for MATCH + LOAD CSV

### DIFF
--- a/cypher-manual/clauses/load-csv.md
+++ b/cypher-manual/clauses/load-csv.md
@@ -50,9 +50,9 @@ available conversion functions.
 :::
 
 :::info
-A MATCH or a MERGE clause can be written prior to LOAD CSV, if the result of 
-the clauses is only one row. Yielding multiple rows before calling LOAD CSV
-will result in a runtime error from Memgraph. The reason for such behaviour 
-is to enable users to match some entities in the graph before running LOAD CSV
-and begin manipulating rows combined with the entities in the graph simultaneously.
+You can write a single MATCH or MERGE clause prior the LOAD CSV clause if and only if the clause returns 
+only one row. Returning multiple rows before calling the LOAD CSV clause will cause a Memgraph 
+runtime error. Adding a MATCH or MERGE clause before the LOAD CSV allows you to match certain 
+entities in the graph before running LOAD CSV, which is an optimization as matched entities
+do not need to be searched for every row in the CSV file.
 :::

--- a/cypher-manual/clauses/load-csv.md
+++ b/cypher-manual/clauses/load-csv.md
@@ -48,3 +48,11 @@ This can be done using the built-in conversion functions such as `ToInteger`,
 `ToFloat`, `ToBoolean` etc. Consult the [documentation](/functions.md) on the
 available conversion functions.
 :::
+
+:::info
+A MATCH or a MERGE clause can be written prior to LOAD CSV, if the result of 
+the clauses is only one row. Yielding multiple rows before calling LOAD CSV
+will result in a runtime error from Memgraph. The reason for such behaviour 
+is to enable users to match some entities in the graph before running LOAD CSV
+and begin manipulating rows combined with the entities in the graph simultaneously.
+:::

--- a/cypher-manual/clauses/load-csv.md
+++ b/cypher-manual/clauses/load-csv.md
@@ -41,18 +41,18 @@ LOAD CSV FROM <csv-file-path> ( WITH | NO ) HEADER [IGNORE BAD] [DELIMITER <deli
 The clause reads row by row from a CSV file and binds the contents of the parsed
 row to the variable you specified.
 
+Adding a `MATCH` or `MERGE` clause before the LOAD CSV allows you to match
+certain entities in the graph before running LOAD CSV, which is an optimization
+as matched entities do not need to be searched for every row in the CSV file.
+
+But, the `MATCH` or `MERGE` clause can be used prior the `LOAD CSV` clause only
+if the clause returns only one row. Returning multiple rows before calling the
+`LOAD CSV` clause will cause a Memgraph runtime error.
+
 :::info
 It's important to note that the parser parses the values as strings.
 It's up to the user to convert the parsed row values to the appropriate type.
 This can be done using the built-in conversion functions such as `ToInteger`,
 `ToFloat`, `ToBoolean` etc. Consult the [documentation](/functions.md) on the
 available conversion functions.
-:::
-
-:::info
-You can write a single MATCH or MERGE clause prior the LOAD CSV clause if and only if the clause returns 
-only one row. Returning multiple rows before calling the LOAD CSV clause will cause a Memgraph 
-runtime error. Adding a MATCH or MERGE clause before the LOAD CSV allows you to match certain 
-entities in the graph before running LOAD CSV, which is an optimization as matched entities
-do not need to be searched for every row in the CSV file.
 :::

--- a/docs/import-data/files/load-csv-clause.md
+++ b/docs/import-data/files/load-csv-clause.md
@@ -24,7 +24,8 @@ If the data is importing slower than expected, you can [speed it
 up](#increase-import-speed) by creating indexes or switching the storage mode to
 analytical.
 
-If the import speed is still unsatisfactory, don't hesitate to contact us on [Discord](https://discord.com/invite/memgraph).
+If the import speed is still unsatisfactory, don't hesitate to contact us on
+[Discord](https://discord.com/invite/memgraph).
 
 :::
 
@@ -110,23 +111,13 @@ When using the `LOAD CSV` clause please keep in mind:
   LOAD CSV FROM "/file.csv" WITH HEADER AS row;
   ```
 
-- Because of the need to use at least two clauses, the clause that exhausts its
-  results sooner will dictate how many times the "loop" is executed. Consider the
-  following query: 
+- Adding a `MATCH` or `MERGE` clause before the LOAD CSV allows you to match
+  certain entities in the graph before running LOAD CSV, which is an optimization
+  as matched entities do not need to be searched for every row in the CSV file.
 
-  ```cypher
-  MATCH (n)
-  LOAD CSV FROM "/file.csv" WITH HEADER AS row
-  SET n.p = row;
-  ```
-
-  If the `MATCH (n)` clause finds five nodes, and the "file.csv" has only two
-  rows, only the first two nodes returned by the `MATCH (n)` will have their
-  properties set, using the two rows from the CSV file. 
-
-  Similarly, if the `MATCH (n)` clause finds two nodes, whereas the "file.csv" has
-  five rows, only the two nodes returned by `MATCH (n)` will have their properties
-  set with the values from the first two rows of the CSV file. 
+  But, the `MATCH` or `MERGE` clause can be used prior the `LOAD CSV` clause only
+  if the clause returns only one row. Returning multiple rows before calling the
+  `LOAD CSV` clause will cause a Memgraph runtime error.
 
 - **The `LOAD CSV` clause can be used at most once per query**, so the queries like the one
   below wll throw an exception: 


### PR DESCRIPTION
### Description

Entering MATCH or MERGE before LOAD CSV can now be done if it results in yielding only one row. Yielding multiple rows before calling LOAD CSV will result in an error.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [X] Documentation improvements

### Checklist:

- [X] I checked all content with Grammarly
- [X] I performed a self-review of my code
- [X] I made corresponding changes to the rest of the documentation
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
