### PR TITLE
Add any type to documentation

### DIFF
--- a/docs/reference-guide/query-modules/implement-custom-query-modules/api/cpp-api.md
+++ b/docs/reference-guide/query-modules/implement-custom-query-modules/api/cpp-api.md
@@ -1872,6 +1872,7 @@ Enumerates the data types supported by Memgraph and its C++ API.
 The types are listed and described [on this page](https://memgraph.com/docs/memgraph/reference-guide/data-types).
 
 - `Type::Null`
+- `Type::Any`
 - `Type::Bool`
 - `Type::Int`
 - `Type::Double`


### PR DESCRIPTION
### Description

MGP Any type enables users to pass any type as argument in the C++ query module without specifying it prior to running Memgraph.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [X] Documentation improvements

### Checklist:

- [X] I checked all content with Grammarly
- [X] I performed a self-review of my code
- [X] I made corresponding changes to the rest of the documentation
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
