### PR TITLE
Add option to insert the snapshot file during creation of container

### DIFF
--- a/docs/reference-guide/backup.md
+++ b/docs/reference-guide/backup.md
@@ -121,7 +121,7 @@ You can easily back up Memgraph by following a four-step process:
 
 Locking the data directory ensures that no files are deleted by the system. 
 
-To restore from back-up:
+To restore from back-up you have two options:
 
 1. Start an instance by adding a `-v ~/snapshots:/var/lib/memgraph/snapshots`
     flag to the `docker run` command, where the `~/snapshots` represents a path to
@@ -130,6 +130,27 @@ To restore from back-up:
     ```
     docker run -p 7687:7687 -p 7444:7444 -v ~/snapshots:/var/lib/memgraph/snapshots memgraph/memgraph
     ```
+
+2. Copy the backed up snapshot file into the `snapshots` directory after the creation of container and start the database. So the commands should look like this: 
+
+    ```
+    docker create -p 7687:7687 -p 7444:7444 -v `snapshots`:/var/lib/memgraph/snapshots --name memgraphDB memgraph/memgraph
+    tar -cf - sample_snapshot_file | docker cp -a  - memgraphDB:/var/lib/memgraph/snapshots
+    ```
+    Here the `sample_snapshot_file` is the name of the snapshot file you want to use to restore the data. Due to the nature of the docker ownership of the files, you need to use `tar` to copy the file as STDIN into non-running container. This way you can give ownership to the file to the `memgraph` user inside the container.
+
+    After that, start the database with:
+    ```
+    docker start -a memgraphDB
+    ```
+    The `-a` flag is used to attach to the container's output so you can see the logs.
+
+    Once memgraph is started, change the snapshot directory ownership to the `memgraph` user, buy running the following command:
+    ```
+    docker exec -it -u 0 memgraphDB bash -c "chown memgraph:memgraph /var/lib/memgraph/snasphots"
+    ```
+    Otherwise, Memgraph will not be able to write the future snapshot files, and will fail.
+
 
 </TabItem>
 <TabItem value='linux'>

--- a/docs/reference-guide/backup.md
+++ b/docs/reference-guide/backup.md
@@ -131,13 +131,13 @@ To restore from back-up you have two options:
     docker run -p 7687:7687 -p 7444:7444 -v ~/snapshots:/var/lib/memgraph/snapshots memgraph/memgraph
     ```
 
-2. Copy the backed up snapshot file into the `snapshots` directory after the creation of container and start the database. So the commands should look like this: 
+2. Copy the backed-up snapshot file into the `snapshots` directory after creating the container and start the database. So the commands should look like this: 
 
     ```
     docker create -p 7687:7687 -p 7444:7444 -v `snapshots`:/var/lib/memgraph/snapshots --name memgraphDB memgraph/memgraph
     tar -cf - sample_snapshot_file | docker cp -a  - memgraphDB:/var/lib/memgraph/snapshots
     ```
-    Here the `sample_snapshot_file` is the name of the snapshot file you want to use to restore the data. Due to the nature of the docker ownership of the files, you need to use `tar` to copy the file as STDIN into non-running container. This way you can give ownership to the file to the `memgraph` user inside the container.
+    Here the `sample_snapshot_file` the snapshot file you want to use to restore the data. Due to the nature of the docker ownership of the files, you need to use `tar` to copy the file as STDIN into the non-running container. This way you can give ownership of the file to the `memgraph` user inside the container.
 
     After that, start the database with:
     ```
@@ -145,11 +145,11 @@ To restore from back-up you have two options:
     ```
     The `-a` flag is used to attach to the container's output so you can see the logs.
 
-    Once memgraph is started, change the snapshot directory ownership to the `memgraph` user, buy running the following command:
+    Once memgraph is started, change the snapshot directory ownership to the `memgraph` user by running the following command:
     ```
     docker exec -it -u 0 memgraphDB bash -c "chown memgraph:memgraph /var/lib/memgraph/snasphots"
     ```
-    Otherwise, Memgraph will not be able to write the future snapshot files, and will fail.
+    Otherwise, Memgraph will not be able to write the future snapshot files and will fail.
 
 
 </TabItem>

--- a/docs/reference-guide/backup.md
+++ b/docs/reference-guide/backup.md
@@ -135,9 +135,9 @@ To restore from back-up you have two options:
 
     ```
     docker create -p 7687:7687 -p 7444:7444 -v `snapshots`:/var/lib/memgraph/snapshots --name memgraphDB memgraph/memgraph
-    tar -cf - sample_snapshot_file | docker cp -a  - memgraphDB:/var/lib/memgraph/snapshots
+    tar -cf - sample_snapshot_file | docker cp -a - memgraphDB:/var/lib/memgraph/snapshots
     ```
-    Here the `sample_snapshot_file` the snapshot file you want to use to restore the data. Due to the nature of the docker ownership of the files, you need to use `tar` to copy the file as STDIN into the non-running container. This way you can give ownership of the file to the `memgraph` user inside the container.
+    The `sample_snapshot_file` is the snapshot file you want to use to restore the data. Due to the nature of Docker file ownership, you need to use `tar` to copy the file as STDIN into the non-running container. It will allow you to change the ownership of the file to the `memgraph` user inside the container.
 
     After that, start the database with:
     ```


### PR DESCRIPTION
### Description

Inserting a snapshot file before Memgraph is started, in purly created container.  The issue is with file ownershiop, you are not able to give a proper file ownership outside of conatiner, this is solution for that type of scenario. 

### Pull request type

- [x] Documentation improvements

### Related PRs and issues

PR this doc page is related to: 
Closes https://github.com/memgraph/memgraph/issues/926


### Checklist:

- [x] I checked all content with Grammarly
- [x] I performed a self-review of my code
- [x] I made corresponding changes to the rest of the documentation
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
