### PR TITLE
[master < E-mage-export] Add MAGE export import documentation

### DIFF
--- a/mage/query-modules/python/export-util.md
+++ b/mage/query-modules/python/export-util.md
@@ -36,11 +36,19 @@ module supports [**exporting database to a JSON file format**](#jsonpath) and [*
 
 <RunOnSubgraph/>
 
-### `json(path)`
+### `json(path, config)`
 
 #### Input:
 
-* `path: string` ➡ Path to the JSON file containing the exported graph database.
+* `path: string = ""` ➡ Path to the JSON file containing the exported graph database.
+* `config: Map` ➡ Map of the configuration with the following keys:
+    - `stream (bool) = False:` ➡ Flag to export the graph data to a stream. By default set to false.
+    - `write_properties (bool) = True:` ➡ Flag to keep node and relationship properties. By default set to true.
+
+#### Output:
+
+* `path: string` ➡ the path to the exported file.
+* `data: string` ➡ exported data if the stream flag was set to true.
 
 #### Usage:
 
@@ -54,7 +62,7 @@ Memgraph.
     {label: 'Docker', value: 'docker'},
     {label: 'Linux', value: 'linux'},
   ]
-}> 
+}>
 
 <TabItem value="docker">
 
@@ -97,6 +105,43 @@ where `path` is the path to a local JSON file that will be created inside the
 
 </Tabs>
 
+### `json_graph(nodes, relationships, path, config)`
+
+Exports the given nodes and relationships to the JSON format. All nodes from the relationships have to be contained in the nodes as well.
+
+#### Input:
+
+* `nodes: List[Node]` ➡ list of nodes to export.
+* `relationships: List[Relationship]` ➡ list of relationships to export.
+* `path: string` ➡ Path to the JSON file containing the exported graph database.
+* `config: Map` ➡ Map of the configuration with the following keys:
+    - `stream (bool) = False:` ➡ Flag to export the graph data to a stream. By default set to false.
+    - `write_properties (bool) = True:` ➡ Flag to keep node and relationship properties. By default set to true.
+
+#### Output:
+
+* `path: string` ➡ the path to the exported file.
+* `data: string` ➡ exported data if the stream flag was set to true.
+
+### `cypher_all(path, config)`
+
+Exports the graph to the cypher query language in the specified file or stream.
+
+#### Input:
+
+* `path: string = ""` ➡ Path to the cypher file containing the exported graph database.
+* `config: Map` ➡ Map of the configuration with the following keys:
+    - `stream (bool) = False:` ➡ Flag to export the graph data to a stream. By default set to false.
+    - `write_properties (bool) = True:` ➡ Flag to keep node and relationship properties. By default set to true.
+    - `write_triggers (bool) = True:` Flag to export graph triggers.
+    - `write_indexes (bool) = True:` Flag to export indexes.
+    - `write_constraints (bool) = True:` Flag to export constraints.
+
+#### Output:
+
+* `path: string` ➡ the path to the exported file.
+* `data: string` ➡ exported data if the stream flag was set to true.
+
 ### `csv_query(query, file_path, stream)`
 
 #### Input:
@@ -122,7 +167,7 @@ Memgraph.
     {label: 'Docker', value: 'docker'},
     {label: 'Linux', value: 'linux'},
   ]
-}> 
+}>
 
 <TabItem value="docker">
 
@@ -194,7 +239,7 @@ CREATE (n)-[:IS_FRIENDS_WITH]->(m), (n)-[:IS_FRIENDS_WITH]->(k), (m)-[:IS_MARRIE
 The image below shows the above data as a graph:
 
 <img src={require('../../data/query-modules/python/export-util/export-util-1.png').default}/>
-    
+
 </TabItem>
 
 <TabItem value="run">
@@ -340,7 +385,7 @@ CREATE
 The image below shows the above data as a graph:
 
 <img src={require('../../data/query-modules/python/export-util/export-util-csv-1.png').default}/>
-    
+
 </TabItem>
 
 <TabItem value="run_csv">
@@ -392,3 +437,41 @@ Erica Sinclair,Priah Ferguson,Stranger Things,2016,"['Matt Duffer', 'Ross Duffer
 </TabItem>
 
 </Tabs>
+
+## Example - Exporting query results to a Cypher file
+
+Running the following on the graph above:
+```cypher
+CALL export_util.cypher_all("export.cyp") YIELD path RETURN path;
+```
+will produce the following `export.cyp` file:
+```plaintext
+CREATE (n:TVShow:_IMPORT_ID {title: 'Stranger Things', released: 2016, program_creators: ['Matt Duffer', 'Ross Duffer'], _IMPORT_ID: 0});
+CREATE (n:Character:_IMPORT_ID {name: 'Eleven', portrayed_by: 'Millie Bobby Brown', _IMPORT_ID: 1});
+CREATE (n:Character:_IMPORT_ID {name: 'Joyce Byers', portrayed_by: 'Millie Bobby Brown', _IMPORT_ID: 2});
+CREATE (n:Character:_IMPORT_ID {name: 'Jim Hopper', portrayed_by: 'Millie Bobby Brown', _IMPORT_ID: 3});
+CREATE (n:Character:_IMPORT_ID {name: 'Mike Wheeler', portrayed_by: 'Finn Wolfhard', _IMPORT_ID: 4});
+CREATE (n:Character:_IMPORT_ID {name: 'Dustin Henderson', portrayed_by: 'Gaten Matarazzo', _IMPORT_ID: 5});
+CREATE (n:Character:_IMPORT_ID {name: 'Lucas Sinclair', portrayed_by: 'Caleb McLaughlin', _IMPORT_ID: 6});
+CREATE (n:Character:_IMPORT_ID {name: 'Nancy Wheeler', portrayed_by: 'Natalia Dyer', _IMPORT_ID: 7});
+CREATE (n:Character:_IMPORT_ID {name: 'Jonathan Byers', portrayed_by: 'Charlie Heaton', _IMPORT_ID: 8});
+CREATE (n:Character:_IMPORT_ID {name: 'Will Byers', portrayed_by: 'Noah Schnapp', _IMPORT_ID: 9});
+CREATE (n:Character:_IMPORT_ID {name: 'Steve Harrington', portrayed_by: 'Joe Keery', _IMPORT_ID: 10});
+CREATE (n:Character:_IMPORT_ID {name: 'Max Mayfield', portrayed_by: 'Sadie Sink', _IMPORT_ID: 11});
+CREATE (n:Character:_IMPORT_ID {name: 'Robin Buckley', portrayed_by: 'Maya Hawke', _IMPORT_ID: 12});
+CREATE (n:Character:_IMPORT_ID {name: 'Erica Sinclair', portrayed_by: 'Priah Ferguson', _IMPORT_ID: 13});
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 1}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 2}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 3}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 4}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 5}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 6}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 7}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 8}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 9}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 10}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [1, 2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 11}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 12}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [3, 4]}]->(m);
+MATCH (n:_IMPORT_ID {_IMPORT_ID: 13}) MATCH (m:_IMPORT_ID {_IMPORT_ID: 0}) CREATE (n)-[:ACTED_IN {seasons: [2, 3, 4]}]->(m);
+MATCH (n:_IMPORT_ID) REMOVE n:`_IMPORT_ID` REMOVE n._IMPORT_ID;
+```

--- a/mage/query-modules/python/import-util.md
+++ b/mage/query-modules/python/import-util.md
@@ -36,6 +36,16 @@ supports only the import of JSON file format.
 
 <RunOnSubgraph/>
 
+### `cypher(path)`
+
+Imports the cypher queries from the given path by just running the queries.
+
+#### Input:
+
+* `path: string` ➡ Path to the Cypher file that is being imported.
+
+This procedure is not fully functional and was created for testing. If you want to import cypher use the Memgraph lab import feature which is fully functional and faster.
+
 ### `json(path)`
 
 #### Input:
@@ -62,7 +72,7 @@ nodes or relationships. If the object is node, then it looks like this:
     "type": "node"
 }
 ```
- 
+
 The `id` key has the value of the Memgraph's internal node ide. The `labels` key
 holds the information about node labels in a list. The `properties` are
 key-value pairs representing properties of the certain node. Each node needs to
@@ -101,7 +111,7 @@ Memgraph.
     {label: 'Docker', value: 'docker'},
     {label: 'Linux', value: 'linux'},
   ]
-}> 
+}>
 
 <TabItem value="docker">
 
@@ -119,7 +129,7 @@ where `path` is the path to the JSON file inside the
 `/usr/lib/memgraph/query_modules/import.json`).
 
 :::info
-You can copy the JSON file to the running Docker container with the [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/) command: 
+You can copy the JSON file to the running Docker container with the [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/) command:
 ```
 docker cp /path_to_local_folder/import.json <container_id>:/usr/lib/memgraph/query_modules/import.json
 ```
@@ -152,11 +162,11 @@ where `path` is the path to a local JSON file that will be created inside the
 }>
 <TabItem value="input">
 
-Below is the content of the `import.json` file. 
+Below is the content of the `import.json` file.
 
 - If you're using **Memgraph with Docker**, then you have to save the
   `import.json` file in the `/usr/lib/memgraph/query_modules` directory inside
-  the running Docker container. 
+  the running Docker container.
 
 - If you're using **Memgraph on Ubuntu, Debian, RPM package or WSL**, then you
   have to save the `import.json` file in the local


### PR DESCRIPTION
### Description

Add MAGE json, json_graph, cypher_all and cypher docs.

### Pull request type

Please delete options that are not relevant and check the ones that are.

- [X] Documentation improvements

### Related PRs and issues

PR this doc page is related to: 
Closes (link to issue):
[PR348](https://github.com/memgraph/mage/pull/348)

### Checklist:

- [X] I checked all content with Grammarly
- [X] I performed a self-review of my code
- [X] I made corresponding changes to the rest of the documentation
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
